### PR TITLE
fix(exe-dev): add rich trigger phrases to command descriptions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
       "name": "exe-dev",
       "source": "./plugins/exe-dev",
       "description": "exe.dev VM management — SSH CLI, HTTP proxy, sharing, and Shelley integration",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "author": {
         "name": "Chad Metcalf"
       }

--- a/plugins/exe-dev/.claude-plugin/plugin.json
+++ b/plugins/exe-dev/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "exe-dev",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "exe.dev VM management — SSH CLI, HTTP proxy, sharing, and Shelley integration"
 }

--- a/plugins/exe-dev/commands/exe-ls.md
+++ b/plugins/exe-dev/commands/exe-ls.md
@@ -1,6 +1,9 @@
 ---
 name: exe-ls
-description: List exe.dev VMs with status
+description: >-
+  List exe.dev VMs with status. Use when the user says "list my VMs", "show my
+  VMs", "what VMs do I have", "exe.dev machines", or any request to see, list,
+  or check existing exe.dev virtual machines.
 allowed-tools:
   - Bash
   - Read

--- a/plugins/exe-dev/commands/exe-new.md
+++ b/plugins/exe-dev/commands/exe-new.md
@@ -1,6 +1,10 @@
 ---
 name: exe-new
-description: Create a new exe.dev VM
+description: >-
+  Create a new exe.dev VM. Use when the user says "create a VM", "make a VM",
+  "spin up a VM", "new VM", "launch a VM", "start a new VM on exe", "make VMs
+  on exe", "set up an exe.dev machine", or any request to create, provision, or
+  launch exe.dev virtual machines.
 argument-hint: "[--image=<image>]"
 allowed-tools:
   - Bash

--- a/plugins/exe-dev/commands/exe-share.md
+++ b/plugins/exe-dev/commands/exe-share.md
@@ -1,6 +1,10 @@
 ---
 name: exe-share
-description: Manage exe.dev VM sharing and public access
+description: >-
+  Manage exe.dev VM sharing and public access. Use when the user says "share my
+  VM", "make VM public", "make VM private", "add access", "share port", "share
+  my server", "make port public", or any request to manage sharing, access
+  control, or public visibility of exe.dev VMs.
 argument-hint: "<vmname> [public|private|add <email>|port <port>]"
 allowed-tools:
   - Bash

--- a/plugins/exe-dev/commands/status.md
+++ b/plugins/exe-dev/commands/status.md
@@ -1,6 +1,9 @@
 ---
 name: status
-description: Quick health check of exe.dev VMs
+description: >-
+  Quick health check of exe.dev VMs. Use when the user says "check my VMs",
+  "VM status", "are my VMs running", "exe.dev status", or any request to check
+  the health or running state of exe.dev virtual machines.
 allowed-tools:
   - Bash
 ---


### PR DESCRIPTION
## Summary
- Added rich trigger phrase lists to all four exe-dev command descriptions (exe-new, exe-ls, exe-share, status) so Claude matches natural language like "make VMs on exe" instead of guessing raw CLI commands
- Bumped exe-dev version 0.2.0 → 0.2.1

Fixes #2

## Test plan
- [ ] Ask Claude to "create a VM on exe" — should invoke exe-dev:exe-new skill
- [ ] Ask Claude to "list my VMs" — should invoke exe-dev:exe-ls skill
- [ ] Ask Claude to "make my VM public" — should invoke exe-dev:exe-share skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)