### PR TITLE
feat(lefthook): add lefthook plugin with mastery skill and punch command

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "chad-tools",
       "description": "Multi-agent code review, AI slop removal, worktree management, and dev workflow automation",
       "source": "./plugins/chad-tools",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "category": "development",
       "author": {
         "name": "Chad Metcalf"
@@ -63,6 +63,16 @@
       "description": "Claude Code CLI knowledge, plugin management guardrails, and automation recommendations",
       "source": "./plugins/claude-craft",
       "version": "0.4.0",
+      "category": "development",
+      "author": {
+        "name": "Chad Metcalf"
+      }
+    },
+    {
+      "name": "lefthook",
+      "description": "Lefthook expertise and interactive git hooks setup wizard — lint, format, test guardrails for any repo",
+      "source": "./plugins/lefthook",
+      "version": "0.1.0",
       "category": "development",
       "author": {
         "name": "Chad Metcalf"

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ claude plugin install fzf-power
 claude plugin install zsh-craft
 claude plugin install exe-dev
 claude plugin install claude-craft
+claude plugin install lefthook
 ```
 
 ```
@@ -218,6 +219,30 @@ Without this plugin, Claude says `claude plugins` (wrong — it's singular), use
 
 ---
 
+## lefthook
+
+**Teaches Claude lefthook and sets up git hook guardrails interactively.**
+
+Without this plugin, Claude sometimes pushes code without running lint, format, or tests. With it, Claude knows how to configure lefthook to enforce code quality checks on every commit and push. The `/punch` command scans your repo, detects your tech stack and existing tools, and generates a `lefthook.yml` tailored to your project.
+
+### What it covers
+
+| Area | What Claude knows |
+|------|-------------------|
+| **Configuration** | Full `lefthook.yml` reference — hook types, job options, file placeholders, parallel/piped execution, output control |
+| **Hook recipes** | Ready-to-paste configs for 12+ languages: JS/TS, Python, Ruby, Go, Rust, Elixir, PHP, Shell, and cross-language patterns |
+| **Advanced patterns** | Monorepo setup, job groups, remote configs, Docker integration, YAML anchors, conditional execution, local overrides |
+| **Setup wizard** | Auto-detects linters, formatters, test runners, type checkers, and CI config — suggests hooks interactively |
+
+### Commands
+
+- `/lefthook:punch` — Analyze repo and interactively set up lefthook guardrails
+- `/lefthook:add` — Request a new feature
+- `/lefthook:issue` — Report a bug
+- `/lefthook:help` — Plugin help
+
+---
+
 ## Contributing
 
 Every plugin has `/help`, `/add`, and `/issue` commands. Request a feature or report a bug right from Claude Code — context is gathered automatically, sensitive data is scrubbed, duplicate issues are checked, and you review before anything gets filed.
@@ -229,6 +254,7 @@ Every plugin has `/help`, `/add`, and `/issue` commands. Request a feature or re
 /fzf-power:add Add a recipe for browsing AWS S3 buckets
 /zsh-craft:add Add coverage for zsh/curses TUI patterns
 /claude-craft:add Add coverage for claude mcp server management patterns
+/lefthook:add Add a recipe for Deno lint and fmt hooks
 ```
 
 Or open an issue directly at [github.com/metcalfc/claude-plugin/issues](https://github.com/metcalfc/claude-plugin/issues).

--- a/plugins/chad-tools/.claude-plugin/plugin.json
+++ b/plugins/chad-tools/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "chad-tools",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Chad's personal Claude Code skills and workflows"
 }

--- a/plugins/chad-tools/commands/audit-plugins.md
+++ b/plugins/chad-tools/commands/audit-plugins.md
@@ -1,7 +1,7 @@
 ---
 name: audit-plugins
 description: (chad-tools) Audit all marketplace plugins for accuracy
-argument-hint: "[gh-recipes|exe-dev|fzf-power|zsh-craft|claude-craft|all]"
+argument-hint: "[gh-recipes|exe-dev|fzf-power|zsh-craft|claude-craft|lefthook|all]"
 allowed-tools:
   - Bash
   - Read
@@ -11,7 +11,7 @@ allowed-tools:
   - Task
 ---
 
-Run a review and test cycle on the gh-recipes, exe-dev, fzf-power, zsh-craft, and claude-craft plugins to verify recipes are still accurate and discover gaps. Default target is `all`.
+Run a review and test cycle on the gh-recipes, exe-dev, fzf-power, zsh-craft, claude-craft, and lefthook plugins to verify recipes are still accurate and discover gaps. Default target is `all`.
 
 ## Workflow
 
@@ -135,6 +135,24 @@ If claude-craft is in scope:
 
 Report claude-craft results in the same table format.
 
-### 10. Recommended Actions
+### 10. Test lefthook
 
-If any recipes need updating, offer to fix them. If new recipes should be added, offer to create them or suggest running `/gh-recipes:add`, `/fzf-power:add`, `/zsh-craft:add`, or `/claude-craft:add`.
+If lefthook is in scope:
+
+1. Check `lefthook version` to verify lefthook is installed
+2. Verify the skill's configuration reference matches current lefthook behavior:
+   - Check that documented options (`parallel`, `piped`, `stage_fixed`, `glob`, `files`, etc.) are still valid
+   - Run `lefthook validate` on a sample config if available
+3. Test the `/punch` command's detection logic:
+   - Verify it detects common project files (package.json, go.mod, Gemfile, etc.)
+   - Verify it correctly identifies linters/formatters from devDependencies
+4. Cross-reference hook recipes against current tool versions:
+   - Check that ESLint, Prettier, RuboCop, Ruff, golangci-lint flags are still valid
+   - Verify commitlint and conventional commit regex patterns work
+5. Check for new lefthook features not yet documented in the skill
+
+Report lefthook results in the same table format.
+
+### 11. Recommended Actions
+
+If any recipes need updating, offer to fix them. If new recipes should be added, offer to create them or suggest running `/gh-recipes:add`, `/fzf-power:add`, `/zsh-craft:add`, `/claude-craft:add`, or `/lefthook:add`.

--- a/plugins/lefthook/.claude-plugin/plugin.json
+++ b/plugins/lefthook/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "lefthook",
+  "version": "0.1.0",
+  "description": "Lefthook expertise and interactive git hooks setup wizard",
+  "repository": "https://github.com/metcalfc/claude-plugin"
+}

--- a/plugins/lefthook/commands/add.md
+++ b/plugins/lefthook/commands/add.md
@@ -1,0 +1,79 @@
+---
+name: add
+description: (lefthook) Request a new feature
+argument-hint: "<description of what's missing>"
+allowed-tools:
+  - Bash
+  - AskUserQuestion
+---
+
+File a GitHub issue on the plugin repo requesting a new lefthook plugin feature.
+
+Take the user's argument as the description of what they tried to do and what was missing.
+
+## Step 1: Check for duplicates
+
+Before filing, search for existing open issues:
+
+```bash
+gh issue list --repo metcalfc/claude-plugin --label "lefthook" --state open --json number,title --jq '.[] | "#\(.number) \(.title)"'
+```
+
+If any existing issue looks related, show the user the matches and ask:
+
+- **File anyway** — the request is different enough to warrant a new issue
+- **Add a comment** — add a "+1" or extra context to the existing issue
+- **Skip** — an existing issue already covers it
+
+If the user picks **Add a comment**, post a comment on the matching issue:
+
+```bash
+gh issue comment ISSUE_NUMBER --repo metcalfc/claude-plugin --body "<comment>"
+```
+
+The comment format:
+
+```markdown
+This might be related — I also ran into this:
+
+<brief description of what the user tried and what was missing>
+
+Adding context in case it helps.
+```
+
+Show the user the draft comment for approval before posting.
+
+## Step 2: Sanitize
+
+Before drafting, scrub the request body of anything sensitive:
+
+- SSH keys, API tokens, passwords, secrets, credentials
+- IP addresses (replace with `<redacted-ip>`)
+- Email addresses not already public on GitHub (replace with `<redacted-email>`)
+- Private repo names or org names if not the plugin repo itself
+- Hostnames of internal/private systems
+- VM hostnames like `*.exe.xyz` (replace with `<vm>.exe.xyz`)
+- File paths containing usernames (replace `/Users/username/` or `/home/username/` with `~/`)
+- Environment variable values (keep the key names, redact values)
+- Branch names if they contain sensitive project info (ask if unsure)
+
+## Step 3: File the issue
+
+```bash
+gh label create lefthook --repo metcalfc/claude-plugin --description "lefthook plugin" --color 0075ca || true
+```
+
+```bash
+gh issue create \
+  --repo metcalfc/claude-plugin \
+  --title "lefthook: <short summary>" \
+  --label "lefthook,enhancement" \
+  --body "<body>"
+```
+
+The body should include:
+- What the user tried to do
+- The error or gap encountered
+- Any workaround they used
+
+After filing, display the issue URL.

--- a/plugins/lefthook/commands/help.md
+++ b/plugins/lefthook/commands/help.md
@@ -1,0 +1,30 @@
+---
+name: help
+description: (lefthook) Plugin help
+allowed-tools: []
+---
+
+Display the following help text to the user:
+
+```
+lefthook — Git hooks expertise and setup wizard
+
+SKILLS (auto-activate based on context):
+  lefthook-mastery    Deep lefthook configuration knowledge — hook types,
+                      job options, file placeholders, parallel execution,
+                      and best practices
+
+COMMANDS:
+  /lefthook:punch     Analyze repo and interactively set up lefthook guardrails
+  /lefthook:add       Request a new feature (files an issue)
+  /lefthook:issue     Report a bug (gathers context, you review before filing)
+  /lefthook:help      This help text
+
+USAGE:
+  The lefthook-mastery skill activates automatically when you're working
+  with lefthook configs or discussing git hooks.
+
+  Use /lefthook:punch in any repo to get an interactive setup wizard that
+  detects your project type, finds existing linters/formatters/test runners,
+  and generates a lefthook.yml with the hooks you choose.
+```

--- a/plugins/lefthook/commands/issue.md
+++ b/plugins/lefthook/commands/issue.md
@@ -1,0 +1,119 @@
+---
+name: issue
+description: (lefthook) Report a bug
+argument-hint: "<what went wrong>"
+allowed-tools:
+  - Bash
+  - Read
+  - AskUserQuestion
+---
+
+Report a bug with the lefthook plugin. Gather context about the failure, sanitize it, and let the user review before filing.
+
+## Step 1: Gather context
+
+Collect the following automatically:
+
+- The skill or command that failed
+- The error message or unexpected behavior
+- The OS (`uname -s`)
+- git version (`git --version`)
+- lefthook version (`lefthook version` if installed)
+
+Use the user's description and recent conversation context to fill in what went wrong.
+
+## Step 2: Sanitize
+
+Before showing the draft to the user, scrub ALL of the following from the issue body:
+
+- SSH keys, API tokens, passwords, secrets, credentials
+- IP addresses (replace with `<redacted-ip>`)
+- Email addresses not already public on GitHub (replace with `<redacted-email>`)
+- Private repo names or org names if not the plugin repo itself
+- Hostnames of internal/private systems
+- VM hostnames like `*.exe.xyz` (replace with `<vm>.exe.xyz`)
+- File paths containing usernames (replace `/Users/username/` or `/home/username/` with `~/`)
+- Environment variable values (keep the key names, redact values)
+- Branch names if they contain sensitive project info (ask if unsure)
+
+## Step 3: Check for duplicates
+
+Before drafting, search for existing open bug reports:
+
+```bash
+gh issue list --repo metcalfc/claude-plugin --label "lefthook,bug" --state open --json number,title --jq '.[] | "#\(.number) \(.title)"'
+```
+
+If any existing issue looks related, show the user the matches and ask:
+
+- **File anyway** — the bug is different enough to warrant a new issue
+- **Add a comment** — post a comment on the existing issue with this new context
+- **Skip** — already reported, nothing to add
+
+If the user picks **Add a comment**, post a comment on the matching issue using the sanitized context from Step 2. Frame it as potentially related:
+
+```bash
+gh issue comment ISSUE_NUMBER --repo metcalfc/claude-plugin --body "<comment>"
+```
+
+The comment format:
+
+```markdown
+This might be related — I hit something similar:
+
+<sanitized description of what happened, the command that failed, and the error>
+
+Let me know if this is a separate issue and I'll file one.
+```
+
+Show the user the draft comment for approval before posting.
+
+## Step 4: Draft and review
+
+Present the full issue title and body to the user using AskUserQuestion with options:
+
+- **File it** — create the issue as drafted
+- **Edit first** — let the user describe what to change, then re-draft
+
+Do NOT file the issue until the user explicitly approves.
+
+## Step 5: File the issue
+
+```bash
+gh label create lefthook --repo metcalfc/claude-plugin --description "lefthook plugin" --color 0075ca || true
+gh label create bug --repo metcalfc/claude-plugin --description "Something isn't working" --color d73a4a || true
+```
+
+```bash
+gh issue create \
+  --repo metcalfc/claude-plugin \
+  --title "lefthook: <short summary>" \
+  --label "lefthook,bug" \
+  --body "<approved body>"
+```
+
+The body format:
+
+```markdown
+## What happened
+
+<description of the problem>
+
+## Skill / command
+
+<the skill or command that failed>
+
+## Error output
+
+```
+<sanitized error output>
+```
+
+## Environment
+
+- OS: <os>
+- git: <version>
+- lefthook: <version or "not installed">
+```
+
+After filing, display the issue URL.

--- a/plugins/lefthook/commands/punch.md
+++ b/plugins/lefthook/commands/punch.md
@@ -1,0 +1,339 @@
+---
+name: punch
+description: (lefthook) Analyze repo and interactively set up lefthook guardrails
+argument-hint: "[focus area: lint, format, test, all]"
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - AskUserQuestion
+  - Write
+  - Edit
+---
+
+Analyze the current repository, detect its tech stack and existing tools, then interactively set up lefthook with git hooks that enforce code quality guardrails.
+
+## Step 1: Check prerequisites
+
+Check if lefthook is installed:
+
+```bash
+command -v lefthook && lefthook version
+```
+
+If not installed, tell the user how to install it for their platform:
+- **macOS**: `brew install lefthook`
+- **npm**: `npm install lefthook --save-dev`
+- **go**: `go install github.com/evilmartians/lefthook/v2@latest`
+- **pip**: `pipx install lefthook`
+
+Do NOT proceed until lefthook is available.
+
+## Step 2: Check for existing config
+
+Look for existing lefthook config files:
+
+Use the Glob tool to check for existing config files matching patterns: `lefthook.yml`, `lefthook.yaml`, `.lefthook.yml`, `.lefthook.yaml`, `lefthook.toml`, `lefthook.json`, `.config/lefthook.yml`.
+
+If a config exists, read it and ask the user:
+- **Enhance** — add to the existing config
+- **Replace** — start fresh
+- **Cancel** — leave it alone
+
+## Step 3: Detect project stack
+
+Scan the repo to identify:
+
+### Package managers and languages
+
+| File | Stack |
+|------|-------|
+| `package.json` | Node.js / JavaScript / TypeScript |
+| `tsconfig.json` | TypeScript |
+| `Gemfile` | Ruby |
+| `go.mod` | Go |
+| `pyproject.toml` or `requirements.txt` or `setup.py` | Python |
+| `Cargo.toml` | Rust |
+| `composer.json` | PHP |
+| `mix.exs` | Elixir |
+| `build.gradle` or `pom.xml` | Java/Kotlin |
+| `*.swift` or `Package.swift` | Swift |
+| `Makefile` | Make-based build |
+
+### Linters and formatters (read package.json deps, Gemfile, etc.)
+
+| Tool | Detection |
+|------|-----------|
+| ESLint | `eslint` in package.json deps/devDeps, or `.eslintrc*` |
+| Prettier | `prettier` in deps, or `.prettierrc*` |
+| Biome | `@biomejs/biome` in deps, or `biome.json` |
+| RuboCop | `rubocop` in Gemfile, or `.rubocop.yml` |
+| Standard (Ruby) | `standard` in Gemfile |
+| Ruff | `ruff` in pyproject.toml or `ruff.toml` |
+| Black | `black` in pyproject.toml deps |
+| Flake8 | `flake8` in deps or `.flake8` |
+| mypy | `mypy` in deps or `mypy.ini` |
+| golangci-lint | `.golangci.yml` or `.golangci.yaml` |
+| gofmt/goimports | Always available if Go detected |
+| Clippy | Always available if Rust detected |
+| rustfmt | Always available if Rust detected |
+| SwiftLint | `.swiftlint.yml` or `swiftlint` in deps |
+| PHP CS Fixer | `php-cs-fixer` in composer.json |
+| Credo | `credo` in mix.exs |
+| mix format | Always available if Elixir detected |
+| markdownlint | `markdownlint` in deps or `.markdownlint*` |
+| shellcheck | `shellcheck` available on PATH |
+| actionlint | `.github/workflows/` directory exists |
+
+### Test runners
+
+| Tool | Detection |
+|------|-----------|
+| Jest | `jest` in deps |
+| Vitest | `vitest` in deps |
+| Mocha | `mocha` in deps |
+| pytest | `pytest` in deps or `pytest.ini` or `conftest.py` |
+| RSpec | `rspec` in Gemfile or `spec/` directory |
+| Minitest | `minitest` in Gemfile or `test/` directory |
+| Go test | `go.mod` exists |
+| cargo test | `Cargo.toml` exists |
+| mix test | `mix.exs` exists |
+| PHPUnit | `phpunit` in composer.json |
+
+### Type checkers
+
+| Tool | Detection |
+|------|-----------|
+| TypeScript (tsc) | `typescript` in deps |
+| mypy | `mypy` in deps |
+| Sorbet | `sorbet` in Gemfile |
+
+### Build tools
+
+Look for build scripts in package.json (`build`, `compile`), Makefiles, or language-specific build commands.
+
+### CI config
+
+Check `.github/workflows/`, `.gitlab-ci.yml`, `Jenkinsfile`, `.circleci/config.yml` for existing CI checks that should be mirrored locally.
+
+## Step 4: Build recommendations
+
+Based on detected tools, prepare hook recommendations in these categories:
+
+### pre-commit hooks (run on every commit)
+- **Linting**: Run detected linters on staged files
+- **Formatting**: Run detected formatters (with `stage_fixed: true` to auto-stage fixes)
+- **Type checking**: Run type checkers if detected
+
+### commit-msg hooks
+- **Conventional commits**: Validate commit message format if the project uses conventional commits (check for `commitlint`, `@commitlint/cli`, or `.commitlintrc*`)
+
+### pre-push hooks (run before push)
+- **Tests**: Run detected test suites
+- **Build**: Run build if build script exists
+- **Type checking**: Full type check (if too slow for pre-commit)
+
+### Custom groups (run manually with `lefthook run <name>`)
+- **fix**: Auto-fix linting and formatting issues
+
+## Step 5: Interactive selection
+
+Present the recommendations to the user organized by hook type. For each recommendation show:
+- What it does
+- The command that will run
+- Which files it targets (glob pattern)
+
+Use AskUserQuestion to let the user choose. Present as a checklist-style selection:
+
+```
+I found the following tools in your repo. Pick which hooks you want:
+
+PRE-COMMIT (runs on every commit):
+  [1] ESLint — lint staged .js/.ts files
+  [2] Prettier — format staged files (auto-stage fixes)
+  [3] TypeScript — type-check
+
+COMMIT-MSG:
+  [4] Conventional commits — enforce commit message format
+
+PRE-PUSH (runs before push):
+  [5] Jest — run test suite
+  [6] Build — run `npm run build`
+
+Type the numbers you want (e.g., "1,2,4,5" or "all"):
+```
+
+If the user passed a focus area argument (lint, format, test, all), pre-select those categories.
+
+## Step 6: Generate lefthook.yml
+
+Build the config using the user's selections. Follow these rules:
+
+### General structure
+```yaml
+pre-commit:
+  parallel: true
+  jobs:
+    - name: <descriptive name>
+      run: <command> {staged_files}
+      glob: "<pattern>"
+```
+
+### Key patterns by tool
+
+**JavaScript/TypeScript linting:**
+```yaml
+- name: eslint
+  run: npx eslint --fix {staged_files}
+  glob: "*.{js,jsx,ts,tsx}"
+  stage_fixed: true
+```
+
+**Prettier formatting:**
+```yaml
+- name: prettier
+  run: npx prettier --write {staged_files}
+  glob: "*.{js,jsx,ts,tsx,css,scss,json,md,yaml,yml}"
+  stage_fixed: true
+```
+
+**Biome (lint + format):**
+```yaml
+- name: biome
+  run: npx biome check --write {staged_files}
+  glob: "*.{js,jsx,ts,tsx,json}"
+  stage_fixed: true
+```
+
+**Ruby linting:**
+```yaml
+- name: rubocop
+  run: bundle exec rubocop --force-exclusion --server {staged_files}
+  glob: "*.rb"
+```
+
+**Ruby formatting (with auto-correct):**
+```yaml
+- name: rubocop-fix
+  run: bundle exec rubocop -A --force-exclusion --server {staged_files}
+  glob: "*.rb"
+  stage_fixed: true
+```
+
+**Python linting:**
+```yaml
+- name: ruff-check
+  run: ruff check --fix {staged_files}
+  glob: "*.py"
+  stage_fixed: true
+```
+
+**Python formatting:**
+```yaml
+- name: ruff-format
+  run: ruff format {staged_files}
+  glob: "*.py"
+  stage_fixed: true
+```
+
+**Go linting:**
+```yaml
+- name: golangci-lint
+  run: golangci-lint run --new-from-rev=HEAD
+  glob: "*.go"
+```
+
+**Go formatting:**
+```yaml
+- name: goimports
+  run: goimports -w {staged_files}
+  glob: "*.go"
+  stage_fixed: true
+```
+
+**Rust:**
+```yaml
+- name: clippy
+  run: cargo clippy -- -D warnings
+  glob: "*.rs"
+
+- name: rustfmt
+  run: rustfmt {staged_files}
+  glob: "*.rs"
+  stage_fixed: true
+```
+
+**Elixir:**
+```yaml
+- name: mix-format
+  run: mix format {staged_files}
+  glob: "*.{ex,exs}"
+  stage_fixed: true
+```
+
+**Conventional commits:**
+```yaml
+commit-msg:
+  jobs:
+    - name: conventional-commit
+      run: 'grep -qE "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: .+" {1} || (echo "Commit message must follow conventional commits format" && exit 1)'
+```
+
+If commitlint is installed:
+```yaml
+commit-msg:
+  jobs:
+    - name: commitlint
+      run: npx commitlint --edit {1}
+```
+
+**Tests (pre-push):**
+```yaml
+pre-push:
+  jobs:
+    - name: test
+      run: npm test
+```
+
+Adjust the test command based on detected runner (pytest, rspec, go test, cargo test, mix test, etc.).
+
+### Output configuration
+
+Add sensible output defaults:
+```yaml
+output:
+  - meta
+  - summary
+  - failure
+```
+
+## Step 7: Write config and install
+
+1. Write the generated `lefthook.yml` to the repo root using the Write tool
+2. Run `lefthook install` to activate the hooks
+3. Show the user what was created with a summary
+
+```
+Done! lefthook.yml created with:
+  - pre-commit: eslint, prettier (auto-fix + stage)
+  - commit-msg: conventional commits
+  - pre-push: jest tests
+
+Hooks are installed. They'll run automatically on your next commit/push.
+
+Tips:
+  - Skip hooks once: LEFTHOOK=0 git commit ...
+  - Run manually: lefthook run pre-commit
+  - Local overrides: create lefthook-local.yml
+  - Add to .gitignore: lefthook-local.yml
+```
+
+## Step 8: Offer extras
+
+After setup, ask if the user wants any of these:
+
+- **Add `lefthook-local.yml` to `.gitignore`** — so devs can customize locally
+- **Add a `fix` group** — manual fixer that auto-corrects all files (not just staged)
+- **Add lefthook install to CI** — ensure hooks stay in sync
+- **Commit the config** — commit lefthook.yml now

--- a/plugins/lefthook/skills/lefthook-mastery/SKILL.md
+++ b/plugins/lefthook/skills/lefthook-mastery/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: lefthook-mastery
+description: >-
+  This skill should be used when the user asks about "lefthook", "git hooks
+  manager", "lefthook.yml", "lefthook config", "pre-commit hooks", "pre-push
+  hooks", "commit-msg hooks", "stage_fixed", "lefthook install", "lefthook
+  run", "lefthook parallel", "lefthook piped", "lefthook skip", "lefthook
+  tags", "lefthook glob", "lefthook scripts", "lefthook docker", "lefthook
+  remotes", "lefthook-local.yml", or when Claude is writing or modifying a
+  lefthook.yml configuration file. Also triggers when the user mentions
+  "git hook guardrails", "enforce lint on commit", "run tests before push",
+  "auto-format on commit", or discusses setting up automated code quality
+  checks tied to git operations.
+---
+
+# Lefthook Configuration Reference
+
+Lefthook is a fast, polyglot Git hooks manager written in Go. Single binary, no dependencies. Use it to enforce code quality guardrails (lint, format, test) on git operations.
+
+For tool-specific hook recipes, see `references/hook-recipes.md`.
+For advanced configuration patterns, see `references/advanced-patterns.md`.
+
+## Installation
+
+```bash
+brew install lefthook        # macOS
+npm install lefthook -D      # Node.js (also yarn, pnpm, bun)
+gem install lefthook         # Ruby
+pipx install lefthook        # Python
+go install github.com/evilmartians/lefthook/v2@latest  # Go
+```
+
+After install: `lefthook install` in the repo root to activate hooks.
+
+## Config File
+
+Primary: `lefthook.yml` (also supports `.lefthook.yml`, `lefthook.toml`, `lefthook.json`, or under `.config/`).
+
+Local overrides: `lefthook-local.yml` — merged on top, never committed. Add to `.gitignore`.
+
+## Top-Level Options
+
+```yaml
+min_version: 1.0.0           # Minimum lefthook version required
+source_dir: ".lefthook"      # Directory for script files (default: .lefthook)
+source_dir_local: ".lefthook-local"  # Local scripts directory
+rc: "~/.bashrc"              # Shell rc file to source before commands
+no_tty: false                # Disable TTY allocation
+colors: true                 # Enable colored output
+skip_lfs: false              # Skip LFS hooks
+assert_lefthook_installed: true  # Fail if lefthook not installed
+no_auto_install: false       # Don't auto-install on git init
+
+output:                      # Control what lefthook prints
+  - meta                     # Show hook name and version
+  - summary                  # Show pass/fail summary
+  - empty_summary            # Show summary even when nothing ran
+  - success                  # Show successful job output
+  - failure                  # Show failed job output
+  - execution                # Show execution details
+  - execution_out            # Show command stdout
+  - execution_info           # Show file list info
+  - skips                    # Show skipped jobs
+```
+
+## Hook Types
+
+Any valid git hook name works. Common ones:
+
+| Hook | When it runs | Typical use |
+|------|-------------|-------------|
+| `pre-commit` | Before commit is created | Lint, format staged files |
+| `commit-msg` | After commit message entered | Validate message format |
+| `pre-push` | Before push to remote | Run tests, build |
+| `post-checkout` | After branch switch | Install deps, rebuild |
+| `post-merge` | After merge completes | Install deps |
+| `prepare-commit-msg` | Before editor opens | Template commit messages |
+
+Custom groups (not tied to git events) can be defined and run manually with `lefthook run <name>`.
+
+## Hook-Level Options
+
+```yaml
+pre-commit:
+  parallel: true             # Run all jobs simultaneously (default: false)
+  piped: true                # Run jobs sequentially, stop on failure (mutually exclusive with parallel)
+  follow: true               # Like piped but continue on failure (mutually exclusive with parallel/piped)
+  skip: true                 # Skip this entire hook
+  only:                      # Only run in specific conditions
+    - ref: main              # Only on specific branch
+  exclude_tags: [slow]       # Exclude jobs with these tags
+  files: "git diff --name-only HEAD"  # Custom file list for all jobs
+  fail_on_changes: true      # Fail if working tree changes after hook
+  fail_on_changes_diff: "git diff"  # Custom diff command for above
+  jobs: [...]                # List of jobs to run
+```
+
+## Job Options
+
+```yaml
+jobs:
+  - name: eslint                        # Required: job name
+    run: npx eslint {staged_files}      # Command to execute
+    glob: "*.{js,ts,jsx,tsx}"           # Filter files by pattern
+    exclude: "vendor/**"                # Exclude files matching pattern
+    files: "git diff --name-only"       # Custom file source command
+    file_types: [text]                  # Filter by file type
+    tags: [frontend, lint]              # Tags for grouping/filtering
+    root: "frontend/"                   # Run from subdirectory
+    env:                                # Environment variables
+      NODE_ENV: test
+    stage_fixed: true                   # Re-stage files after command (for auto-fix)
+    interactive: true                   # Allocate TTY for interactive commands
+    use_stdin: true                     # Pass file list via stdin
+    priority: 1                         # Execution order (lower = first, with piped)
+    fail_text: "ESLint found errors"    # Custom failure message
+    skip:                               # Skip conditions
+      - merge                           # Skip during merges
+      - rebase                          # Skip during rebases
+      - ref: main                       # Skip on branch
+    only:
+      - ref: "feature/*"               # Only on matching branches
+```
+
+## File Placeholders
+
+Use in `run` commands — lefthook substitutes them with actual file lists:
+
+| Placeholder | Resolves to |
+|-------------|-------------|
+| `{staged_files}` | Files in git staging area (most common for pre-commit) |
+| `{push_files}` | Files changed between HEAD and remote (for pre-push) |
+| `{all_files}` | All tracked files in repo |
+| `{files}` | Files from custom `files` command |
+| `{1}` | First argument (e.g., commit message file path for commit-msg) |
+
+## Script Support
+
+Instead of inline `run` commands, use script files:
+
+```yaml
+pre-commit:
+  jobs:
+    - script: "check-large-files.sh"
+      runner: bash
+```
+
+Scripts live in `source_dir` (default `.lefthook/`):
+```
+.lefthook/
+  pre-commit/
+    check-large-files.sh
+```
+
+## Key Patterns
+
+### Auto-fix and re-stage
+Use `stage_fixed: true` with formatters so fixed files get staged automatically:
+```yaml
+- name: prettier
+  run: npx prettier --write {staged_files}
+  glob: "*.{js,ts,css,json,md}"
+  stage_fixed: true
+```
+
+### Parallel for speed
+Run independent linters simultaneously:
+```yaml
+pre-commit:
+  parallel: true
+  jobs:
+    - name: eslint
+      run: npx eslint {staged_files}
+      glob: "*.{js,ts}"
+    - name: stylelint
+      run: npx stylelint {staged_files}
+      glob: "*.{css,scss}"
+```
+
+### Monorepo with root
+Scope jobs to subdirectories:
+```yaml
+- name: lint-api
+  root: "api/"
+  run: bundle exec rubocop {staged_files}
+  glob: "*.rb"
+```
+
+### Skip during rebase
+Avoid running hooks during rebase operations:
+```yaml
+- name: tests
+  run: npm test
+  skip:
+    - rebase
+    - merge
+```
+
+### Disable temporarily
+```bash
+LEFTHOOK=0 git commit -m "skip hooks this once"
+```
+
+## CLI Commands
+
+| Command | Purpose |
+|---------|---------|
+| `lefthook install` | Set up git hooks from config |
+| `lefthook uninstall` | Remove lefthook git hooks |
+| `lefthook run <hook>` | Run a hook manually |
+| `lefthook validate` | Validate config syntax |
+| `lefthook dump` | Show merged config (with remotes/extends) |
+| `lefthook version` | Show version |

--- a/plugins/lefthook/skills/lefthook-mastery/references/advanced-patterns.md
+++ b/plugins/lefthook/skills/lefthook-mastery/references/advanced-patterns.md
@@ -1,0 +1,304 @@
+# Lefthook Advanced Patterns
+
+## Monorepo Configuration
+
+Use `root` to scope jobs to subdirectories. Each job only sees files within its root:
+
+```yaml
+pre-commit:
+  parallel: true
+  jobs:
+    - name: lint-frontend
+      root: "frontend/"
+      run: npx eslint {staged_files}
+      glob: "*.{js,ts,tsx}"
+
+    - name: lint-backend
+      root: "backend/"
+      run: bundle exec rubocop {staged_files}
+      glob: "*.rb"
+
+    - name: lint-api
+      root: "api/"
+      run: golangci-lint run --new-from-rev=HEAD
+      glob: "*.go"
+```
+
+## Job Groups
+
+Nest jobs within a group for scoped parallel/piped execution:
+
+```yaml
+pre-commit:
+  jobs:
+    - group:
+        name: frontend
+        parallel: true
+        jobs:
+          - name: eslint
+            run: npx eslint {staged_files}
+            glob: "*.{js,ts}"
+          - name: stylelint
+            run: npx stylelint {staged_files}
+            glob: "*.{css,scss}"
+    - group:
+        name: backend
+        piped: true
+        jobs:
+          - name: rubocop
+            run: bundle exec rubocop {staged_files}
+            glob: "*.rb"
+          - name: rspec
+            run: bundle exec rspec --fail-fast
+```
+
+## Remote Configs
+
+Pull lefthook config from a shared repo (org-wide standards):
+
+```yaml
+remotes:
+  - git_url: https://github.com/org/lefthook-configs
+    ref: main
+    configs:
+      - lefthook-common.yml
+```
+
+With refetch control:
+```yaml
+remotes:
+  - git_url: https://github.com/org/lefthook-configs
+    ref: main
+    refetch: true
+    refetch_frequency: "24h"
+    configs:
+      - base.yml
+      - security.yml
+```
+
+## Extends
+
+Extend from local config files:
+
+```yaml
+extends:
+  - .lefthook/base.yml
+  - .lefthook/team-overrides.yml
+```
+
+## Conditional Execution
+
+### Skip conditions
+
+Skip a job during specific git operations:
+```yaml
+- name: tests
+  run: npm test
+  skip:
+    - merge        # Skip during merge
+    - rebase       # Skip during rebase
+    - ref: main    # Skip on main branch
+```
+
+Skip the entire hook:
+```yaml
+pre-commit:
+  skip:
+    - merge
+    - rebase
+```
+
+### Only conditions
+
+Run a job only in specific conditions:
+```yaml
+- name: deploy-check
+  run: ./scripts/validate-deploy.sh
+  only:
+    - ref: "release/*"    # Only on release branches
+```
+
+## Environment Variables
+
+Set per-job environment:
+```yaml
+- name: test
+  run: pytest
+  env:
+    DATABASE_URL: "sqlite:///test.db"
+    DJANGO_SETTINGS_MODULE: "project.settings.test"
+```
+
+Global env via `rc`:
+```yaml
+rc: "~/.bashrc"    # Source this file before all commands
+```
+
+## Piped Execution
+
+Run jobs sequentially — each waits for the previous to succeed:
+
+```yaml
+pre-push:
+  piped: true
+  jobs:
+    - name: lint
+      run: npm run lint
+      priority: 1           # Runs first
+    - name: type-check
+      run: npx tsc --noEmit
+      priority: 2           # Runs second
+    - name: test
+      run: npm test
+      priority: 3           # Runs last
+```
+
+Use `follow: true` instead of `piped: true` to continue even if earlier jobs fail.
+
+## Docker Integration
+
+Run hooks inside containers:
+
+```yaml
+pre-commit:
+  jobs:
+    - name: rubocop-docker
+      run: docker compose run --rm app bundle exec rubocop {staged_files}
+      glob: "*.rb"
+```
+
+## Templates
+
+Use YAML anchors to define reusable job fragments:
+
+```yaml
+.lint-defaults: &lint-defaults
+  stage_fixed: true
+  skip:
+    - merge
+    - rebase
+
+pre-commit:
+  parallel: true
+  jobs:
+    - name: eslint
+      run: npx eslint --fix {staged_files}
+      glob: "*.{js,ts}"
+      <<: *lint-defaults
+    - name: prettier
+      run: npx prettier --write {staged_files}
+      glob: "*.{js,ts,css,json,md}"
+      <<: *lint-defaults
+```
+
+The anchor `&lint-defaults` defines the template, and `<<: *lint-defaults` merges it into each job.
+
+## Output Configuration
+
+Control verbosity:
+
+```yaml
+# Minimal — only show failures
+output:
+  - failure
+
+# Verbose — show everything
+output:
+  - meta
+  - summary
+  - success
+  - failure
+  - execution
+  - execution_out
+  - execution_info
+  - skips
+
+# Balanced (recommended)
+output:
+  - meta
+  - summary
+  - failure
+```
+
+## Local Overrides
+
+`lefthook-local.yml` merges on top of the main config. Use it for:
+
+### Skip slow jobs locally
+```yaml
+pre-push:
+  exclude_tags: [slow]
+```
+
+### Add personal jobs
+```yaml
+pre-commit:
+  jobs:
+    - name: my-custom-check
+      run: ./my-script.sh
+```
+
+### Disable a hook entirely
+```yaml
+pre-push:
+  skip: true
+```
+
+## Custom Manual Groups
+
+Define groups that aren't tied to git events — run with `lefthook run <name>`:
+
+```yaml
+# Fix all files (not just staged)
+fix:
+  jobs:
+    - name: eslint-fix
+      run: npx eslint --fix {all_files}
+      glob: "*.{js,ts}"
+    - name: prettier-fix
+      run: npx prettier --write {all_files}
+      glob: "*.{js,ts,css,json,md}"
+
+# Full audit
+audit:
+  jobs:
+    - name: npm-audit
+      run: npm audit
+    - name: license-check
+      run: npx license-checker --failOn "GPL"
+```
+
+Run: `lefthook run fix` or `lefthook run audit`
+
+## Performance Tips
+
+1. **Use `parallel: true`** for independent jobs (linters, formatters)
+2. **Use `{staged_files}`** instead of `{all_files}` in pre-commit — only check what changed
+3. **Use `glob`** to avoid passing irrelevant files to tools
+4. **Use `--server` flag** for RuboCop (keeps daemon running)
+5. **Move slow checks to pre-push** instead of pre-commit
+6. **Use `skip: [rebase, merge]`** to avoid running during non-authoring operations
+7. **Use `tags` + `exclude_tags`** in local config to skip slow jobs during rapid iteration
+
+## Migration from Other Tools
+
+### From husky
+Replace `.husky/pre-commit` scripts with lefthook.yml jobs. Remove husky from package.json. Run `lefthook install`.
+
+### From pre-commit (Python)
+Map `.pre-commit-config.yaml` repos/hooks to lefthook.yml jobs. Each hook becomes a job with `run` and `glob`.
+
+### From overcommit
+Map `.overcommit.yml` hook definitions to lefthook.yml. Similar structure but different syntax.
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Hook not running | Run `lefthook install` to reinstall |
+| Wrong files passed | Check `glob` pattern, use `lefthook run <hook> --verbose` |
+| Config not loading | Run `lefthook dump` to see merged config |
+| Slow hooks | Move to pre-push, use parallel, narrow glob |
+| Hooks run during rebase | Add `skip: [rebase]` to the job |
+| Need to skip once | `LEFTHOOK=0 git commit ...` |
+| Hook fails in CI | Set `LEFTHOOK=0` in CI env, or use `assert_lefthook_installed: false` |

--- a/plugins/lefthook/skills/lefthook-mastery/references/hook-recipes.md
+++ b/plugins/lefthook/skills/lefthook-mastery/references/hook-recipes.md
@@ -1,0 +1,351 @@
+# Lefthook Hook Recipes
+
+Ready-to-use job configurations organized by language and purpose.
+
+## JavaScript / TypeScript
+
+### ESLint (lint)
+```yaml
+- name: eslint
+  run: npx eslint {staged_files}
+  glob: "*.{js,jsx,ts,tsx}"
+```
+
+### ESLint with auto-fix
+```yaml
+- name: eslint-fix
+  run: npx eslint --fix {staged_files}
+  glob: "*.{js,jsx,ts,tsx}"
+  stage_fixed: true
+```
+
+### Prettier (format)
+```yaml
+- name: prettier
+  run: npx prettier --write {staged_files}
+  glob: "*.{js,jsx,ts,tsx,css,scss,less,json,md,yaml,yml,html}"
+  stage_fixed: true
+```
+
+### Biome (lint + format)
+```yaml
+- name: biome
+  run: npx biome check --write {staged_files}
+  glob: "*.{js,jsx,ts,tsx,json,jsonc}"
+  stage_fixed: true
+```
+
+### TypeScript type check
+```yaml
+- name: tsc
+  run: npx tsc --noEmit
+  glob: "*.{ts,tsx}"
+```
+
+### Jest tests (pre-push)
+```yaml
+- name: jest
+  run: npx jest --bail --passWithNoTests
+```
+
+### Vitest tests (pre-push)
+```yaml
+- name: vitest
+  run: npx vitest run
+```
+
+### commitlint (commit-msg)
+```yaml
+- name: commitlint
+  run: npx commitlint --edit {1}
+```
+
+### npm audit
+```yaml
+- name: audit
+  run: npm audit --audit-level=high
+  tags: [security]
+```
+
+## Python
+
+### Ruff (lint + fix)
+```yaml
+- name: ruff-check
+  run: ruff check --fix {staged_files}
+  glob: "*.py"
+  stage_fixed: true
+```
+
+### Ruff (format)
+```yaml
+- name: ruff-format
+  run: ruff format {staged_files}
+  glob: "*.py"
+  stage_fixed: true
+```
+
+### Black (format)
+```yaml
+- name: black
+  run: black {staged_files}
+  glob: "*.py"
+  stage_fixed: true
+```
+
+### Flake8 (lint)
+```yaml
+- name: flake8
+  run: flake8 {staged_files}
+  glob: "*.py"
+```
+
+### mypy (type check)
+```yaml
+- name: mypy
+  run: mypy {staged_files}
+  glob: "*.py"
+```
+
+### pytest (pre-push)
+```yaml
+- name: pytest
+  run: pytest -x --tb=short
+```
+
+## Ruby
+
+### RuboCop (lint)
+```yaml
+- name: rubocop
+  run: bundle exec rubocop --force-exclusion --server {staged_files}
+  glob: "*.rb"
+```
+
+### RuboCop (auto-correct)
+```yaml
+- name: rubocop-fix
+  run: bundle exec rubocop -A --force-exclusion --server {staged_files}
+  glob: "*.rb"
+  stage_fixed: true
+```
+
+### Standard Ruby
+```yaml
+- name: standardrb
+  run: bundle exec standardrb --fix {staged_files}
+  glob: "*.rb"
+  stage_fixed: true
+```
+
+### RSpec (pre-push)
+```yaml
+- name: rspec
+  run: bundle exec rspec --fail-fast
+```
+
+### Minitest (pre-push)
+```yaml
+- name: minitest
+  run: bundle exec rails test
+```
+
+### ERB Lint
+```yaml
+- name: erb-lint
+  run: bundle exec erblint {staged_files}
+  glob: "*.erb"
+```
+
+### Brakeman (security)
+```yaml
+- name: brakeman
+  run: bundle exec brakeman --no-pager -q
+  tags: [security]
+```
+
+## Go
+
+### golangci-lint
+```yaml
+- name: golangci-lint
+  run: golangci-lint run --new-from-rev=HEAD
+  glob: "*.go"
+```
+
+### gofmt
+```yaml
+- name: gofmt
+  run: gofmt -w {staged_files}
+  glob: "*.go"
+  stage_fixed: true
+```
+
+### goimports
+```yaml
+- name: goimports
+  run: goimports -w {staged_files}
+  glob: "*.go"
+  stage_fixed: true
+```
+
+### Go test (pre-push)
+```yaml
+- name: go-test
+  run: go test ./...
+```
+
+### Go vet
+```yaml
+- name: go-vet
+  run: go vet ./...
+  glob: "*.go"
+```
+
+## Rust
+
+### Clippy (lint)
+```yaml
+- name: clippy
+  run: cargo clippy -- -D warnings
+  glob: "*.rs"
+```
+
+### rustfmt (format)
+```yaml
+- name: rustfmt
+  run: rustfmt {staged_files}
+  glob: "*.rs"
+  stage_fixed: true
+```
+
+### Cargo test (pre-push)
+```yaml
+- name: cargo-test
+  run: cargo test
+```
+
+## Elixir
+
+### mix format
+```yaml
+- name: mix-format
+  run: mix format {staged_files}
+  glob: "*.{ex,exs}"
+  stage_fixed: true
+```
+
+### Credo (lint)
+```yaml
+- name: credo
+  run: mix credo {staged_files}
+  glob: "*.{ex,exs}"
+```
+
+### mix test (pre-push)
+```yaml
+- name: mix-test
+  run: mix test
+```
+
+## PHP
+
+### PHP CS Fixer
+```yaml
+- name: php-cs-fixer
+  run: php-cs-fixer fix {staged_files}
+  glob: "*.php"
+  stage_fixed: true
+```
+
+### PHPStan
+```yaml
+- name: phpstan
+  run: phpstan analyse {staged_files}
+  glob: "*.php"
+```
+
+### PHPUnit (pre-push)
+```yaml
+- name: phpunit
+  run: vendor/bin/phpunit
+```
+
+## Shell
+
+### ShellCheck
+```yaml
+- name: shellcheck
+  run: shellcheck {staged_files}
+  glob: "*.{sh,bash,zsh}"
+```
+
+### shfmt
+```yaml
+- name: shfmt
+  run: shfmt -w {staged_files}
+  glob: "*.{sh,bash}"
+  stage_fixed: true
+```
+
+## Cross-language
+
+### Conventional commits (commit-msg)
+
+Without commitlint:
+```yaml
+commit-msg:
+  jobs:
+    - name: conventional-commit
+      run: >-
+        grep -qE "^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?(!)?: .+" {1}
+        || (echo "ERROR: Commit message must follow Conventional Commits format" && exit 1)
+```
+
+### Check for large files
+```yaml
+- name: no-large-files
+  run: >-
+    for f in {staged_files}; do
+      size=$(wc -c < "$f");
+      if [ "$size" -gt 1048576 ]; then
+        echo "ERROR: $f is larger than 1MB ($size bytes)";
+        exit 1;
+      fi;
+    done
+  tags: [safety]
+```
+
+### Prevent debug markers
+```yaml
+- name: no-debug
+  run: >-
+    grep -rn "binding.pry\|debugger\|console.log\|import pdb\|breakpoint()" {staged_files}
+    && echo "ERROR: Debug statements found" && exit 1
+    || true
+  tags: [safety]
+```
+
+### markdownlint
+```yaml
+- name: markdownlint
+  run: npx markdownlint {staged_files}
+  glob: "*.md"
+```
+
+### actionlint (GitHub Actions)
+```yaml
+- name: actionlint
+  run: actionlint {staged_files}
+  glob: ".github/workflows/*.{yml,yaml}"
+```
+
+### Secrets detection
+```yaml
+- name: detect-secrets
+  run: >-
+    grep -rn "AKIA\|sk-\|ghp_\|glpat-\|xoxb-\|-----BEGIN" {staged_files}
+    && echo "ERROR: Possible secrets detected" && exit 1
+    || true
+  tags: [security]
+```


### PR DESCRIPTION
## Summary

- New `lefthook` plugin that teaches Claude lefthook configuration and provides `/punch` — an interactive setup wizard that detects project stack, finds existing linters/formatters/test runners, and generates `lefthook.yml` with user-selected git hook guardrails
- Includes `lefthook-mastery` skill with comprehensive hook recipes (12+ languages) and advanced patterns (monorepo, Docker, remotes, groups)
- Updates audit-plugins, README, and marketplace registry; bumps chad-tools to 1.4.1

## Test plan

- [ ] Install plugin: `claude plugin install lefthook`
- [ ] Verify `/lefthook:help` displays help text
- [ ] Test `/lefthook:punch` in a JS/TS repo — confirm stack detection and config generation
- [ ] Test `/lefthook:punch` in a Python repo — confirm ruff/pytest detection
- [ ] Verify `lefthook-mastery` skill activates when asking about lefthook configuration
- [ ] Run `/chad-tools:audit-plugins lefthook` to verify audit integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)