### PR TITLE
feat: add /prep command and shared lefthook config

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "chad-tools",
       "description": "Multi-agent code review, AI slop removal, worktree management, and dev workflow automation",
       "source": "./plugins/chad-tools",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "category": "development",
       "author": {
         "name": "Chad Metcalf"
@@ -72,7 +72,7 @@
       "name": "lefthook",
       "description": "Lefthook expertise and interactive git hooks setup wizard — lint, format, test guardrails for any repo",
       "source": "./plugins/lefthook",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "category": "development",
       "author": {
         "name": "Chad Metcalf"

--- a/plugins/chad-tools/.claude-plugin/plugin.json
+++ b/plugins/chad-tools/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "chad-tools",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Chad's personal Claude Code skills and workflows"
 }

--- a/plugins/chad-tools/agents/issue-prepper.md
+++ b/plugins/chad-tools/agents/issue-prepper.md
@@ -1,0 +1,54 @@
+---
+name: issue-prepper
+description: Preps a single GitHub issue for autonomous AI execution. Rewrites the
+  issue body into a structured format with goal, success criteria, steps, context,
+  and constraints.
+model: sonnet
+---
+
+You prep GitHub issues for autonomous AI execution. You fetch an issue, rewrite its body into a structured format, show it for review, and update it.
+
+## Workflow
+
+1. **Fetch the issue** using `gh issue view <number> --repo <repo> --json number,title,body,labels,comments`
+2. **Extract context**: title, body, and comments (formatted as `[author]: comment body`)
+3. **Rewrite the body** into the structured format below
+4. **Show the proposed body** to the user via AskUserQuestion with options: "Update issue", "Edit first", "Skip"
+5. **If "Edit first"**: incorporate feedback, show again
+6. **If "Update issue"**: apply via `gh issue edit`
+7. **If title starts with "WIP:"**: strip the prefix
+
+## Structured Format
+
+Reorganize the issue into this exact structure. Keep ALL existing requirements and context — don't lose information — but make it actionable for an AI agent working unattended.
+
+```markdown
+## Goal
+One sentence: what does "done" look like?
+
+## Success Criteria
+- [ ] Checkboxes with verifiable conditions (test commands, lint checks, behavior)
+- [ ] Include specific commands to run when the repo has them
+
+## Steps
+1. Numbered, ordered implementation steps
+2. Reference specific files and functions when known
+3. Include what to read/understand first
+
+## Context
+- Links to related issues/PRs
+- Key decisions already made
+- Things NOT to touch (scope boundaries)
+
+## Constraints
+- Technical constraints (no new deps, backwards compat, etc.)
+```
+
+If the original issue is too vague for concrete steps, add a `## Open Questions` section listing what needs answering instead of guessing.
+
+## Rules
+
+- The repo tools context provided in your prompt tells you what verification commands exist. Reference them in Success Criteria.
+- Output ONLY the new issue body markdown when rewriting — no wrapping, no explanation.
+- Keep the rewrite concise but complete. Don't add fluff.
+- If comments contain important decisions or clarifications, incorporate them into the body so the agent doesn't need to read comments separately.

--- a/plugins/chad-tools/commands/prep.md
+++ b/plugins/chad-tools/commands/prep.md
@@ -1,0 +1,162 @@
+---
+name: prep
+description: (chad-tools) Prep GitHub issues for autonomous AI execution
+argument-hint: "<issue#> | <epic#> | <range like 1-3,5,7>"
+allowed-tools:
+  - Bash
+  - Read
+  - Glob
+  - Grep
+  - Agent
+  - AskUserQuestion
+---
+
+Rewrite GitHub issue bodies into a structured format optimized for autonomous AI execution. Supports single issues, umbrella/epic issues with sub-issues, and arbitrary ranges.
+
+## Step 1: Parse arguments
+
+The argument `$ARGUMENTS` specifies which issues to prep. Parse it into a list of issue numbers.
+
+**Formats:**
+
+- **Single issue**: `5` — one issue number
+- **Range**: `1-3,5,7,13-20` — comma-separated numbers and ranges, expand to individual numbers
+- **No argument**: error — tell the user to provide an issue number
+
+## Step 2: Detect the repo
+
+Determine the GitHub repo to operate on:
+
+```bash
+gh repo view --json nameWithOwner -q '.nameWithOwner'
+```
+
+## Step 3: Repo preflight
+
+Scan the repo root for available verification tools. Build a context string listing what's available:
+
+- `CLAUDE.md` — repo-level instructions
+- `lefthook.yml` / `.lefthook.yml` — git hook stages (pre-commit, pre-push, etc.)
+- `Makefile` — targets: test, lint, check, format, build
+- `package.json` — scripts: test, lint, format, check, build, typecheck. Detect package manager (bun/pnpm/yarn/npm) from lock files.
+- `Cargo.toml` — cargo: test, build, clippy
+- `go.mod` — go: test, build, vet
+- `pyproject.toml` / `setup.py` — pytest, ruff
+- `Gemfile` — rake, rspec, rails test
+- `.github/workflows/` — GitHub Actions CI
+
+Format as a bulleted list under `## Repo Tools`.
+
+## Step 4: Route by count
+
+### Single issue (1 issue number)
+
+Do the prep inline — proceed to Step 5.
+
+### Multiple issues (2+ issue numbers)
+
+First, check if any of the issues are umbrella/epic issues. For each issue number, fetch its body and check for a task list pattern (`- [ ] #123` or `- [x] #123`). If an issue has sub-issues:
+
+1. Extract the sub-issue numbers from the task list
+2. Add those to the prep list (deduplicating)
+3. Mark the umbrella issue to be prepped LAST (after all sub-issues are done)
+
+Then launch parallel `issue-prepper` agents for all non-umbrella issues. Pass each agent:
+- The issue number
+- The repo name
+- The repo tools context from Step 3
+
+Wait for all agents to complete, then prep any umbrella issues (also in parallel if multiple). For umbrellas, include a summary of what the sub-issues cover so the umbrella prep has full context.
+
+### Single issue that's an epic
+
+If there's only 1 issue number but it has a task list with sub-issue references (`- [ ] #123`):
+
+Use AskUserQuestion to ask:
+- **Prep as umbrella** — prep all sub-issues in parallel, then prep the umbrella
+- **Prep just this issue** — treat it as a regular single issue
+
+## Step 5: Prep a single issue (inline path)
+
+### 5a: Fetch issue context
+
+```bash
+gh issue view <number> --repo <repo> --json number,title,body,labels,comments
+```
+
+Extract: title, body, comments (formatted as `[author]: comment body`).
+
+### 5b: Build the rewrite prompt
+
+Construct a prompt with:
+- The issue number and title
+- The current issue body
+- Comments (if any)
+- Repo tools context from Step 3
+- The structured format template (see below)
+
+### 5c: Rewrite the issue
+
+The rewrite should reorganize the issue into this exact structure, keeping all existing requirements and context — don't lose information:
+
+```markdown
+## Goal
+One sentence: what does "done" look like?
+
+## Success Criteria
+- [ ] Checkboxes with verifiable conditions (test commands, lint checks, behavior)
+- [ ] Include specific commands to run when the repo has them
+
+## Steps
+1. Numbered, ordered implementation steps
+2. Reference specific files and functions when known
+3. Include what to read/understand first
+
+## Context
+- Links to related issues/PRs
+- Key decisions already made
+- Things NOT to touch (scope boundaries)
+
+## Constraints
+- Technical constraints (no new deps, backwards compat, etc.)
+- If the original issue is too vague for concrete steps, add a ## Open Questions section
+```
+
+### 5d: Review and confirm
+
+Show the proposed new issue body to the user via AskUserQuestion. Options:
+- **Update issue** — apply the rewrite
+- **Edit first** — let user provide feedback, then revise and ask again
+- **Skip** — don't update this issue
+
+### 5e: Apply the update
+
+```bash
+gh issue edit <number> --repo <repo> --body-file <(cat <<'BODY'
+<new body here>
+BODY
+)
+```
+
+If the title starts with `WIP:`, strip that prefix:
+
+```bash
+gh issue edit <number> --repo <repo> --title "<clean title>"
+```
+
+Confirm the update to the user.
+
+## Agent dispatch format
+
+When launching `issue-prepper` agents in parallel, use this prompt template:
+
+```
+Prep GitHub issue #<NUMBER> in repo <REPO> for autonomous AI execution.
+
+## Repo Tools
+<repo tools context>
+
+Fetch the issue, rewrite its body into the structured prep format, show the user for review, and update it.
+```
+
+The agent knows the structured format and the full workflow. Pass it everything it needs in the prompt.

--- a/plugins/lefthook/.claude-plugin/plugin.json
+++ b/plugins/lefthook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lefthook",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Lefthook expertise and interactive git hooks setup wizard",
   "repository": "https://github.com/metcalfc/claude-plugin"
 }

--- a/plugins/lefthook/commands/help.md
+++ b/plugins/lefthook/commands/help.md
@@ -16,6 +16,7 @@ SKILLS (auto-activate based on context):
 
 COMMANDS:
   /lefthook:punch     Analyze repo and interactively set up lefthook guardrails
+  /lefthook:setup     Configure a shared lefthook config repo for this project
   /lefthook:add       Request a new feature (files an issue)
   /lefthook:issue     Report a bug (gathers context, you review before filing)
   /lefthook:help      This help text
@@ -27,4 +28,12 @@ USAGE:
   Use /lefthook:punch in any repo to get an interactive setup wizard that
   detects your project type, finds existing linters/formatters/test runners,
   and generates a lefthook.yml with the hooks you choose.
+
+SHARED CONFIG:
+  If your org has a shared lefthook config repo, run:
+    /lefthook:setup https://github.com/org/lefthook-config
+
+  This saves settings to .claude/lefthook.local.md (not committed).
+  Then /lefthook:punch will include the shared config via `remotes:`
+  and layer project-specific hooks on top.
 ```

--- a/plugins/lefthook/commands/punch.md
+++ b/plugins/lefthook/commands/punch.md
@@ -14,6 +14,20 @@ allowed-tools:
 
 Analyze the current repository, detect its tech stack and existing tools, then interactively set up lefthook with git hooks that enforce code quality guardrails.
 
+## Step 0: Check for shared config
+
+Check if `.claude/lefthook.local.md` exists in the project root. If it does, read it and parse the YAML frontmatter.
+
+Expected fields:
+- `remote_repo` — Git URL for shared lefthook config (e.g., `https://github.com/org/lefthook-config`)
+- `remote_ref` — Branch/tag to use (default: `main`)
+- `remote_configs` — List of config files to pull (e.g., `["base.yml", "security.yml"]`)
+- `refetch_frequency` — How often to refetch (default: `"24h"`)
+
+If a shared config exists, the generated `lefthook.yml` in Step 6 MUST include a `remotes:` block pulling from it. The shared config provides baseline hooks — the user's local selections layer on top.
+
+If the file doesn't exist, skip this step and proceed normally.
+
 ## Step 1: Check prerequisites
 
 Check if lefthook is installed:
@@ -169,6 +183,22 @@ If the user passed a focus area argument (lint, format, test, all), pre-select t
 ## Step 6: Generate lefthook.yml
 
 Build the config using the user's selections. Follow these rules:
+
+### Shared remote config (if configured in Step 0)
+
+If `.claude/lefthook.local.md` specified a remote repo, add a `remotes:` block at the top of the config:
+
+```yaml
+remotes:
+  - git_url: <remote_repo>
+    ref: <remote_ref>
+    refetch: true
+    refetch_frequency: "<refetch_frequency>"
+    configs:
+      - <each config file from remote_configs>
+```
+
+The remote provides baseline hooks. Local jobs defined below add to or override them.
 
 ### General structure
 ```yaml

--- a/plugins/lefthook/commands/setup.md
+++ b/plugins/lefthook/commands/setup.md
@@ -1,0 +1,78 @@
+---
+name: setup
+description: (lefthook) Configure shared lefthook config repo for this project
+argument-hint: "<git-url> [ref] [config-files...]"
+allowed-tools:
+  - Bash
+  - Read
+  - Write
+  - AskUserQuestion
+---
+
+Configure a shared lefthook config repo for this project by creating `.claude/lefthook.local.md`.
+
+## Step 1: Gather config
+
+If `$ARGUMENTS` is provided, parse it:
+- First arg: git URL (e.g., `https://github.com/org/lefthook-config`)
+- Second arg (optional): ref/branch (default: `main`)
+- Remaining args (optional): config file names (default: ask)
+
+If no arguments, use AskUserQuestion to ask:
+1. **Git URL** — the shared lefthook config repo URL
+2. **Branch/tag** — which ref to track (default: `main`)
+
+## Step 2: Discover config files
+
+If config files weren't specified in args, try to list what's available in the remote repo:
+
+```bash
+gh api repos/<owner>/<repo>/contents --jq '.[].name' 2>/dev/null | grep -E '\.(yml|yaml)$'
+```
+
+If that works (public repo or user has access), present the files and let the user pick via AskUserQuestion.
+
+If it fails (private repo, no access), ask the user to type the config file names.
+
+## Step 3: Write settings file
+
+Ensure `.claude/` directory exists:
+
+```bash
+mkdir -p .claude
+```
+
+Write `.claude/lefthook.local.md`:
+
+```markdown
+---
+remote_repo: "<git-url>"
+remote_ref: "<ref>"
+remote_configs: ["<file1.yml>", "<file2.yml>"]
+refetch_frequency: "24h"
+---
+
+# Shared Lefthook Config
+
+Remote: <git-url> (ref: <ref>)
+Configs: <file list>
+
+Run `/lefthook:punch` to generate lefthook.yml with this shared config as a base.
+```
+
+## Step 4: Check gitignore
+
+Check if `.claude/*.local.md` is in `.gitignore`:
+
+```bash
+grep -q '\.claude/\*\.local\.md' .gitignore 2>/dev/null
+```
+
+If not, offer to add it.
+
+## Step 5: Confirm
+
+Tell the user:
+- Settings saved to `.claude/lefthook.local.md`
+- Run `/lefthook:punch` to generate hooks with the shared config as a base
+- The shared config provides baseline hooks; `/punch` will layer project-specific hooks on top

--- a/plugins/lefthook/skills/lefthook-mastery/references/advanced-patterns.md
+++ b/plugins/lefthook/skills/lefthook-mastery/references/advanced-patterns.md
@@ -76,6 +76,21 @@ remotes:
       - security.yml
 ```
 
+### Plugin integration
+
+If the user has configured a shared config via `/lefthook:setup`, it's stored in `.claude/lefthook.local.md`:
+
+```yaml
+---
+remote_repo: "https://github.com/org/lefthook-config"
+remote_ref: "main"
+remote_configs: ["base.yml", "security.yml"]
+refetch_frequency: "24h"
+---
+```
+
+When generating `lefthook.yml`, include the `remotes:` block from these settings. The shared config provides org-wide baseline hooks; local jobs layer on top.
+
 ## Extends
 
 Extend from local config files:


### PR DESCRIPTION
## Summary
- Add `/prep` command to chad-tools — rewrites GitHub issues into structured format (Goal/Success Criteria/Steps/Context/Constraints) for autonomous AI execution. Supports single issues, umbrella/epic parallel prep, and range syntax (`1-3,5,7,13-20`).
- Add `issue-prepper` agent (sonnet) for parallel dispatch when prepping multiple issues.
- Add `/lefthook:setup` command — configures shared lefthook config repos via `.claude/lefthook.local.md` (gitignored, private). `/punch` now reads this and includes `remotes:` in generated configs.

## Test plan
- [ ] Run `/prep <issue#>` on a single issue — verify structured rewrite and review flow
- [ ] Run `/prep <range>` on multiple issues — verify parallel agent dispatch
- [ ] Run `/prep <epic#>` on an issue with task list — verify sub-issue detection and umbrella prep
- [ ] Run `/lefthook:setup https://github.com/org/repo` — verify `.claude/lefthook.local.md` creation
- [ ] Run `/lefthook:punch` with settings file present — verify `remotes:` block in generated config

🤖 Generated with [Claude Code](https://claude.com/claude-code)