### PR TITLE
fix: rename commands that collide with built-in Claude Code slash commands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "chad-tools",
       "description": "Multi-agent code review, AI slop removal, worktree management, and dev workflow automation",
       "source": "./plugins/chad-tools",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "category": "development",
       "author": {
         "name": "Chad Metcalf"
@@ -22,7 +22,7 @@
       "name": "exe-dev",
       "description": "exe.dev VM management — SSH CLI, HTTP proxy, sharing, and Shelley integration",
       "source": "./plugins/exe-dev",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "category": "development",
       "author": {
         "name": "Chad Metcalf"
@@ -42,7 +42,7 @@
       "name": "fzf-power",
       "description": "Teaches Claude to use fzf's full power — preview windows, keybindings, theming, and advanced patterns instead of bare | fzf",
       "source": "./plugins/fzf-power",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "category": "productivity",
       "author": {
         "name": "Chad Metcalf"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A collection of plugins for [Claude Code](https://docs.anthropic.com/en/docs/cla
 
 **The problem:** Claude Code is good at general programming but has blind spots. It writes `bash` when you're in `zsh`. It uses bare `| fzf` without previews. It doesn't know `gh milestone list` isn't a real command. These plugins fix that by giving Claude domain-specific knowledge that activates automatically when relevant.
 
-**How plugins work:** Skills auto-activate based on context (mention a VM and exe-dev kicks in, write a zsh script and zsh-craft takes over). Commands are explicit (`/review`, `/exe-ls`). You install what you need — they're independent.
+**How plugins work:** Skills auto-activate based on context (mention a VM and exe-dev kicks in, write a zsh script and zsh-craft takes over). Commands are explicit (`/code-review`, `/exe-ls`). You install what you need — they're independent.
 
 ## Install
 
@@ -34,7 +34,7 @@ claude plugin install lefthook
 
 **Multi-agent code review and dev workflow automation.**
 
-The headline feature is `/review` — a single command that auto-detects what you've changed (unstaged, staged, last commit), selects the right review agents, runs them in parallel, and either posts a GitHub review (if a PR exists) or reports findings in your terminal. It also reviews PRs by number (`/review #123`).
+The headline feature is `/code-review` — a single command that auto-detects what you've changed (unstaged, staged, last commit), selects the right review agents, runs them in parallel, and either posts a GitHub review (if a PR exists) or reports findings in your terminal. It also reviews PRs by number (`/code-review #123`).
 
 Five specialized agents, each focused on a different aspect of code quality:
 
@@ -52,7 +52,7 @@ Agent selection uses comprehensive trigger patterns across Go, Rust, JS/TS, Pyth
 
 | Command | What it does |
 |---------|-------------|
-| `/chad-tools:review` | Multi-agent code review — local diff or PR |
+| `/chad-tools:code-review` | Multi-agent code review — local diff or PR |
 | `/chad-tools:deslop` | Strip AI code slop from branch diff |
 | `/chad-tools:humanize` | Rewrite prose to remove AI writing patterns |
 | `/chad-tools:done` | Mark worktree done for cwprune |
@@ -121,7 +121,7 @@ Without this plugin, Claude writes `something | fzf` and calls it a day. With it
 
 ### Commands
 
-- `/fzf-power:theme` — Browse and apply fzf color themes to your shell profile
+- `/fzf-power:fzf-theme` — Browse and apply fzf color themes to your shell profile
 - `/fzf-power:add` — Request a new recipe or pattern
 - `/fzf-power:issue` — Report a bug
 - `/fzf-power:help` — Plugin help
@@ -179,7 +179,7 @@ Without this plugin, Claude doesn't know that `ssh exe.dev new` creates a VM, th
 - `/exe-ls` — List VMs with status
 - `/exe-new` — Create a new VM
 - `/exe-share` — Share a VM
-- `/exe-dev:status` — Quick health check of all VMs
+- `/exe-dev:exe-status` — Quick health check of all VMs
 - `/exe-dev:add` — Request a new feature
 - `/exe-dev:issue` — Report a bug
 - `/exe-dev:help` — Plugin help

--- a/plugins/chad-tools/.claude-plugin/plugin.json
+++ b/plugins/chad-tools/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "chad-tools",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Chad's personal Claude Code skills and workflows"
 }

--- a/plugins/chad-tools/commands/babysit-prs.md
+++ b/plugins/chad-tools/commands/babysit-prs.md
@@ -103,9 +103,9 @@ If the user says "Skip this PR", abort the rebase (`git rebase --abort`) and mov
 
 ### 2c: Review the Conflict Resolution
 
-Run `/review` on the changes introduced by the conflict resolution. The review scope is the diff between the original HEAD and the new rebased HEAD — use the commit range.
+Run `/code-review` on the changes introduced by the conflict resolution. The review scope is the diff between the original HEAD and the new rebased HEAD — use the commit range.
 
-If `/review` produces **Fix Now** items, fix them.
+If `/code-review` produces **Fix Now** items, fix them.
 
 ### 2d: Simplify Gate
 

--- a/plugins/chad-tools/commands/code-review.md
+++ b/plugins/chad-tools/commands/code-review.md
@@ -1,5 +1,5 @@
 ---
-name: review
+name: code-review
 description: (chad-tools) Multi-agent code review — local diff or PR
 argument-hint: "[#PR|unstaged|staged|last|HEAD~N|<file>...]"
 allowed-tools:

--- a/plugins/chad-tools/commands/help.md
+++ b/plugins/chad-tools/commands/help.md
@@ -17,7 +17,7 @@ SKILLS (auto-activate based on context):
   resolve-reviews     Reply to PR review comments and resolve conversations
 
 COMMANDS:
-  /chad-tools:review         Multi-agent code review (local diff or PR)
+  /chad-tools:code-review    Multi-agent code review (local diff or PR)
   /chad-tools:deslop         Strip AI code slop from branch diff
   /chad-tools:humanize       Rewrite prose to remove AI writing patterns
   /chad-tools:done           Mark worktree done for cwprune

--- a/plugins/exe-dev/.claude-plugin/plugin.json
+++ b/plugins/exe-dev/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "exe-dev",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "exe.dev VM management — SSH CLI, HTTP proxy, sharing, and Shelley integration"
 }

--- a/plugins/exe-dev/commands/exe-status.md
+++ b/plugins/exe-dev/commands/exe-status.md
@@ -1,5 +1,5 @@
 ---
-name: status
+name: exe-status
 description: (exe-dev) Quick VM health check
 allowed-tools:
   - Bash

--- a/plugins/exe-dev/commands/help.md
+++ b/plugins/exe-dev/commands/help.md
@@ -13,14 +13,14 @@ COMMANDS:
   /exe-ls             List VMs with status
   /exe-new            Create a new VM
   /exe-share          Share a VM
-  /exe-dev:status     Quick health check of all VMs
+  /exe-dev:exe-status Quick health check of all VMs
   /exe-dev:add        Request a new feature (files an issue)
   /exe-dev:issue      Report a bug (gathers context, you review before filing)
   /exe-dev:help       This help text
 
 USAGE:
   /exe-ls                    List all VMs
-  /exe-dev:status            Quick summary of VM health
+  /exe-dev:exe-status        Quick summary of VM health
   /exe-new ubuntu            Create a new Ubuntu VM
   /exe-share my-vm           Share a VM with someone
 ```

--- a/plugins/fzf-power/.claude-plugin/plugin.json
+++ b/plugins/fzf-power/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fzf-power",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Teaches Claude to use fzf's full power — preview windows, keybindings, theming, and advanced patterns",
   "repository": "https://github.com/metcalfc/claude-plugin"
 }

--- a/plugins/fzf-power/commands/fzf-theme.md
+++ b/plugins/fzf-power/commands/fzf-theme.md
@@ -1,6 +1,6 @@
 ---
-name: theme
-description: (fzf-power) Browse and apply color themes
+name: fzf-theme
+description: (fzf-power) Browse and apply fzf color themes
 allowed-tools:
   - Bash
   - Read

--- a/plugins/fzf-power/commands/help.md
+++ b/plugins/fzf-power/commands/help.md
@@ -25,7 +25,7 @@ REFERENCES (loaded as needed):
   examples          Real-world recipes: git, docker, k8s, processes, files
 
 COMMANDS:
-  /fzf-power:theme  Browse and apply fzf color themes
+  /fzf-power:fzf-theme  Browse and apply fzf color themes
   /fzf-power:add    Request a new fzf recipe or pattern (files an issue)
   /fzf-power:issue  Report a bug (gathers context, you review before filing)
   /fzf-power:help   This help text


### PR DESCRIPTION
## Summary
- Renamed `review` → `code-review` (chad-tools) to avoid collision with built-in `/review`
- Renamed `status` → `exe-status` (exe-dev) to avoid collision with built-in `/status`
- Renamed `theme` → `fzf-theme` (fzf-power) to avoid collision with built-in `/theme`

Updated all references in README, help commands, babysit-prs, and bumped patch versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)