### PR TITLE
feat: resolve issues #12, #9, #4 from triage review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "chad-tools",
       "description": "Multi-agent code review, AI slop removal, worktree management, and dev workflow automation",
       "source": "./plugins/chad-tools",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "category": "development",
       "author": {
         "name": "Chad Metcalf"
@@ -22,7 +22,7 @@
       "name": "exe-dev",
       "description": "exe.dev VM management — SSH CLI, HTTP proxy, sharing, and Shelley integration",
       "source": "./plugins/exe-dev",
-      "version": "0.2.3",
+      "version": "0.3.0",
       "category": "development",
       "author": {
         "name": "Chad Metcalf"
@@ -72,7 +72,7 @@
       "name": "lefthook",
       "description": "Lefthook expertise and interactive git hooks setup wizard — lint, format, test guardrails for any repo",
       "source": "./plugins/lefthook",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "category": "development",
       "author": {
         "name": "Chad Metcalf"

--- a/plugins/chad-tools/.claude-plugin/plugin.json
+++ b/plugins/chad-tools/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "chad-tools",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Chad's personal Claude Code skills and workflows"
 }

--- a/plugins/chad-tools/agents/issue-prepper.md
+++ b/plugins/chad-tools/agents/issue-prepper.md
@@ -1,21 +1,20 @@
 ---
 name: issue-prepper
-description: Preps a single GitHub issue for autonomous AI execution. Rewrites the
-  issue body into a structured format with goal, success criteria, steps, context,
-  and constraints.
+description: Preps a single GitHub issue for autonomous AI execution. Posts a structured
+  execution plan as a comment with goal, success criteria, steps, context, and constraints.
 model: sonnet
 ---
 
-You prep GitHub issues for autonomous AI execution. You fetch an issue, rewrite its body into a structured format, show it for review, and update it.
+You prep GitHub issues for autonomous AI execution. You fetch an issue, build a structured execution plan, show it for review, and post it as a comment on the issue while preserving the original body.
 
 ## Workflow
 
 1. **Fetch the issue** using `gh issue view <number> --repo <repo> --json number,title,body,labels,comments`
 2. **Extract context**: title, body, and comments (formatted as `[author]: comment body`)
-3. **Rewrite the body** into the structured format below
-4. **Show the proposed body** to the user via AskUserQuestion with options: "Update issue", "Edit first", "Skip"
+3. **Build an execution plan** using the structured format below
+4. **Show the proposed plan** to the user via AskUserQuestion with options: "Post plan", "Edit first", "Skip"
 5. **If "Edit first"**: incorporate feedback, show again
-6. **If "Update issue"**: apply via `gh issue edit`
+6. **If "Post plan"**: post the plan as a comment via `gh issue comment`, then append a link to the comment at the bottom of the original issue body (after a `---` rule). Preserve the original body verbatim.
 7. **If title starts with "WIP:"**: strip the prefix
 
 ## Structured Format
@@ -49,6 +48,7 @@ If the original issue is too vague for concrete steps, add a `## Open Questions`
 ## Rules
 
 - The repo tools context provided in your prompt tells you what verification commands exist. Reference them in Success Criteria.
-- Output ONLY the new issue body markdown when rewriting — no wrapping, no explanation.
-- Keep the rewrite concise but complete. Don't add fluff.
-- If comments contain important decisions or clarifications, incorporate them into the body so the agent doesn't need to read comments separately.
+- Output ONLY the execution plan markdown — no wrapping, no explanation.
+- Keep the plan concise but complete. Don't add fluff.
+- If comments contain important decisions or clarifications, incorporate them into the plan so the agent doesn't need to read comments separately.
+- NEVER overwrite the original issue body. Post the plan as a comment, then append a link to it at the bottom of the original body.

--- a/plugins/chad-tools/commands/prep.md
+++ b/plugins/chad-tools/commands/prep.md
@@ -11,7 +11,7 @@ allowed-tools:
   - AskUserQuestion
 ---
 
-Rewrite GitHub issue bodies into a structured format optimized for autonomous AI execution. Supports single issues, umbrella/epic issues with sub-issues, and arbitrary ranges.
+Post structured execution plans as comments on GitHub issues, optimized for autonomous AI execution. Preserves the original issue body and links to the plan comment. Supports single issues, umbrella/epic issues with sub-issues, and arbitrary ranges.
 
 ## Step 1: Parse arguments
 
@@ -95,9 +95,9 @@ Construct a prompt with:
 - Repo tools context from Step 3
 - The structured format template (see below)
 
-### 5c: Rewrite the issue
+### 5c: Build the execution plan
 
-The rewrite should reorganize the issue into this exact structure, keeping all existing requirements and context — don't lose information:
+Build a structured execution plan from the issue, keeping all existing requirements and context — don't lose information:
 
 ```markdown
 ## Goal
@@ -124,19 +124,37 @@ One sentence: what does "done" look like?
 
 ### 5d: Review and confirm
 
-Show the proposed new issue body to the user via AskUserQuestion. Options:
-- **Update issue** — apply the rewrite
+Show the proposed execution plan to the user via AskUserQuestion. Options:
+- **Post plan** — add as a comment and link from the body
 - **Edit first** — let user provide feedback, then revise and ask again
 - **Skip** — don't update this issue
 
-### 5e: Apply the update
+### 5e: Post the plan as a comment and link from the body
+
+Post the execution plan as a comment on the issue:
 
 ```bash
-gh issue edit <number> --repo <repo> --body-file <(cat <<'BODY'
-<new body here>
+gh issue comment <number> --repo <repo> --body-file <(cat <<'BODY'
+## Execution Plan
+
+<plan content here>
 BODY
 )
 ```
+
+Then append a link to the plan comment at the bottom of the **original** issue body. Fetch the comment URL from the command output or via `gh api`, then update the body:
+
+```bash
+gh issue edit <number> --repo <repo> --body-file <(cat <<'BODY'
+<original body unchanged>
+
+---
+📋 [Execution plan](#issuecomment-<id>)
+BODY
+)
+```
+
+**Important:** The original issue body MUST be preserved verbatim. Only append the plan link after a horizontal rule.
 
 If the title starts with `WIP:`, strip that prefix:
 
@@ -156,7 +174,7 @@ Prep GitHub issue #<NUMBER> in repo <REPO> for autonomous AI execution.
 ## Repo Tools
 <repo tools context>
 
-Fetch the issue, rewrite its body into the structured prep format, show the user for review, and update it.
+Fetch the issue, build a structured execution plan, show the user for review, and post it as a comment on the issue (preserving the original body).
 ```
 
 The agent knows the structured format and the full workflow. Pass it everything it needs in the prompt.

--- a/plugins/exe-dev/.claude-plugin/plugin.json
+++ b/plugins/exe-dev/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "exe-dev",
-  "version": "0.2.3",
+  "version": "0.3.0",
   "description": "exe.dev VM management — SSH CLI, HTTP proxy, sharing, and Shelley integration"
 }

--- a/plugins/exe-dev/commands/exe-ls.md
+++ b/plugins/exe-dev/commands/exe-ls.md
@@ -10,9 +10,11 @@ List the user's exe.dev virtual machines.
 
 Run `ssh exe.dev ls --json` and parse the output with `jq`.
 
-Present results as a table with columns: Name, Status, Image, URL.
+Present results as a table with columns: Name, Alias, Status, Image, URL.
 
 The URL for each VM is `https://<vm_name>.exe.xyz` and SSH is `ssh <vm_name>.exe.xyz`.
+
+To populate the Alias column, read `~/.ssh/config` and look for `Host <alias>` entries whose `HostName` matches `<vm_name>.exe.xyz`. Show the alias if found, or `-` if no alias exists.
 
 If the command fails, check whether the user has SSH keys configured for exe.dev and suggest adding an SSH config entry:
 

--- a/plugins/exe-dev/commands/exe-new.md
+++ b/plugins/exe-dev/commands/exe-new.md
@@ -5,6 +5,8 @@ argument-hint: "[--image=<image>]"
 allowed-tools:
   - Bash
   - Read
+  - Edit
+  - AskUserQuestion
 ---
 
 Create a new exe.dev virtual machine.
@@ -26,3 +28,27 @@ After creation, parse the output and present:
 - Shelley URL (`https://<vmname>.shelley.exe.xyz/`)
 
 Remind the user the VM is private by default. To make it public: `ssh exe.dev share set-public <vmname>`.
+
+## SSH config alias
+
+After VM creation, offer to add an SSH alias to `~/.ssh/config` via AskUserQuestion:
+
+- **Add SSH alias** — ask for a friendly name (or suggest one based on VM purpose), then add it
+- **Skip** — don't touch SSH config
+
+If the user wants an alias:
+
+1. Read `~/.ssh/config`
+2. Ensure the exe.dev wildcard block exists (add at the end if missing):
+   ```
+   Host exe.dev *.exe.xyz
+     IdentitiesOnly yes
+     IdentityFile ~/.ssh/id_ed25519
+   ```
+3. Add a Host alias entry after the wildcard block:
+   ```
+   Host <alias>
+     HostName <vmname>.exe.xyz
+   ```
+4. Use the Edit tool to modify `~/.ssh/config` — NEVER overwrite the entire file
+5. Confirm to the user: `ssh <alias>` is now available

--- a/plugins/lefthook/.claude-plugin/plugin.json
+++ b/plugins/lefthook/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lefthook",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Lefthook expertise and interactive git hooks setup wizard",
   "repository": "https://github.com/metcalfc/claude-plugin"
 }

--- a/plugins/lefthook/commands/punch.md
+++ b/plugins/lefthook/commands/punch.md
@@ -365,5 +365,32 @@ After setup, ask if the user wants any of these:
 
 - **Add `lefthook-local.yml` to `.gitignore`** — so devs can customize locally
 - **Add a `fix` group** — manual fixer that auto-corrects all files (not just staged)
-- **Add lefthook install to CI** — ensure hooks stay in sync
+- **Add lefthook install to CI** — ensure hooks stays in sync
 - **Commit the config** — commit lefthook.yml now
+
+## Step 9: Offer to update CLAUDE.md with hooks policy
+
+Check if a `CLAUDE.md` exists in the repo root. Use AskUserQuestion to offer:
+
+- **Update CLAUDE.md** — add a Git Hooks section documenting the hooks policy
+- **Skip** — don't touch CLAUDE.md
+
+If the user chooses to update, add (or update if a `## Git Hooks` section already exists) a section like this:
+
+```markdown
+## Git Hooks
+
+This project uses [lefthook](https://github.com/evilmartians/lefthook) for git hooks.
+
+Configured hooks:
+- **pre-commit**: <list the configured pre-commit jobs>
+- **commit-msg**: <list if configured>
+- **pre-push**: <list the configured pre-push jobs>
+
+**Policy:**
+- NEVER skip hooks (`--no-verify`, `LEFTHOOK=0`) without explicit user permission
+- If a hook fails, fix the underlying issue — do not bypass the hook
+- Local overrides go in `lefthook-local.yml` (not tracked by git)
+```
+
+Tailor the hook list to what was actually configured in Step 6. Only list hook stages that have jobs.


### PR DESCRIPTION
## Summary
- **#12 prep**: Post execution plan as a comment instead of rewriting the issue body, preserving original context
- **#9 lefthook punch**: Add Step 9 offering to update CLAUDE.md with hooks policy after setup; fix labels from bug/chad-tools to enhancement/lefthook
- **#4 exe-dev**: exe-new offers SSH config alias via AskUserQuestion; exe-ls shows aliases in table

## Test plan
- [ ] Run `/prep` on a test issue and verify plan is posted as comment with body link
- [ ] Run `/lefthook:punch` and verify Step 9 offers CLAUDE.md update
- [ ] Run `/exe-dev:exe-new` and verify SSH alias prompt appears after VM creation
- [ ] Run `/exe-dev:exe-ls` and verify Alias column appears in output

Closes #12, closes #9, closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)