### PR TITLE
feat(exe-dev): add HTTPS API, templates, Shelley updates, and VSCode integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,9 +20,9 @@
     },
     {
       "name": "exe-dev",
-      "description": "exe.dev VM management — SSH CLI, HTTP proxy, sharing, and Shelley integration",
+      "description": "exe.dev VM management — SSH CLI, HTTPS API, HTTP proxy, sharing, templates, and Shelley integration",
       "source": "./plugins/exe-dev",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "category": "development",
       "author": {
         "name": "Chad Metcalf"

--- a/plugins/exe-dev/.claude-plugin/plugin.json
+++ b/plugins/exe-dev/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "exe-dev",
-  "version": "0.3.0",
-  "description": "exe.dev VM management — SSH CLI, HTTP proxy, sharing, and Shelley integration"
+  "version": "0.4.0",
+  "description": "exe.dev VM management — SSH CLI, HTTPS API, HTTP proxy, sharing, templates, and Shelley integration"
 }

--- a/plugins/exe-dev/commands/add.md
+++ b/plugins/exe-dev/commands/add.md
@@ -60,7 +60,7 @@ Before drafting, scrub the request body of anything sensitive:
 ## Step 3: File the issue
 
 ```bash
-gh label create exe-dev --repo metcalfc/claude-plugin --description "exe-dev plugin" --color 0075ca 2>/dev/null
+gh label create exe-dev --repo metcalfc/claude-plugin --description "exe-dev plugin" --color 0075ca || true
 ```
 
 ```bash

--- a/plugins/exe-dev/commands/help.md
+++ b/plugins/exe-dev/commands/help.md
@@ -7,20 +7,25 @@ allowed-tools: []
 Display the following help text to the user:
 
 ```
-exe-dev — exe.dev VM management via SSH CLI
+exe-dev — exe.dev VM management via SSH CLI and HTTPS API
 
 COMMANDS:
-  /exe-ls             List VMs with status
-  /exe-new            Create a new VM
-  /exe-share          Share a VM
-  /exe-dev:exe-status Quick health check of all VMs
-  /exe-dev:add        Request a new feature (files an issue)
-  /exe-dev:issue      Report a bug (gathers context, you review before filing)
-  /exe-dev:help       This help text
+  /exe-ls              List VMs with status
+  /exe-new             Create a new VM
+  /exe-share           Manage VM sharing and public access
+  /exe-status          Quick health check of all VMs
+  /exe-dev:add         Request a new feature (files an issue)
+  /exe-dev:issue       Report a bug (gathers context, you review before filing)
+  /exe-dev:help        This help text
+
+SKILL:
+  exe-dev-knowledge    SSH CLI, HTTPS API, HTTP proxy, sharing, templates,
+                       LLM gateway, email, Shelley, custom domains, VSCode
 
 USAGE:
   /exe-ls                    List all VMs
-  /exe-dev:exe-status        Quick summary of VM health
-  /exe-new ubuntu            Create a new Ubuntu VM
-  /exe-share my-vm           Share a VM with someone
+  /exe-status                Quick summary of VM health
+  /exe-new                   Create a VM (default image)
+  /exe-new --image=ubuntu    Create a VM with specific image
+  /exe-share my-vm           Manage sharing for a VM
 ```

--- a/plugins/exe-dev/commands/issue.md
+++ b/plugins/exe-dev/commands/issue.md
@@ -79,8 +79,8 @@ Do NOT file the issue until the user explicitly approves.
 ## Step 5: File the issue
 
 ```bash
-gh label create exe-dev --repo metcalfc/claude-plugin --description "exe-dev plugin" --color 0075ca 2>/dev/null
-gh label create bug --repo metcalfc/claude-plugin --description "Something isn't working" --color d73a4a 2>/dev/null
+gh label create exe-dev --repo metcalfc/claude-plugin --description "exe-dev plugin" --color 0075ca || true
+gh label create bug --repo metcalfc/claude-plugin --description "Something isn't working" --color d73a4a || true
 ```
 
 ```bash

--- a/plugins/exe-dev/skills/exe-dev-knowledge/SKILL.md
+++ b/plugins/exe-dev/skills/exe-dev-knowledge/SKILL.md
@@ -12,15 +12,19 @@ description: >-
   "set up custom domain", "configure DNS", "LLM gateway", "proxy port",
   "send email from VM". Also triggers on SSH-related phrases:
   "SSH into my", "SSH proxy", "SSH to my VM", "ssh exe", "connect to my VM",
-  "remote into". Also triggers when the user mentions Shelley agent or
+  "remote into". Also triggers on API and tokens: "exe.dev API",
+  "exe0 token", "exe1 token", "API token", "programmatic access".
+  Also triggers on templates: "idea template", "exe.new", "VM template".
+  Also triggers on IDE integration: "vscode exe", "code server".
+  Also triggers when the user mentions Shelley agent or
   works with exe.dev infrastructure in any way. Provides comprehensive
-  knowledge of the exe.dev platform, SSH CLI, HTTP proxy, sharing,
-  custom domains, LLM gateway, email, and VM management.
+  knowledge of the exe.dev platform, SSH CLI, HTTPS API, HTTP proxy,
+  sharing, custom domains, LLM gateway, email, templates, and VM management.
 ---
 
 # exe.dev Platform Knowledge
 
-exe.dev is a subscription VM service. SSH **is** the CLI — there is no binary to install. VMs get persistent disks, instant HTTPS, and built-in auth.
+exe.dev is a subscription VM service. SSH **is** the CLI — there is no binary to install. VMs get persistent disks, instant HTTPS, and built-in auth. Also has an HTTPS API for programmatic access.
 
 ## Documentation
 
@@ -28,6 +32,11 @@ Upstream docs for the latest information:
 
 - Docs index: https://exe.dev/docs.md
 - All docs in one page: https://exe.dev/docs/all.md
+
+Detailed reference files in `references/`:
+- `api-tokens.md` — HTTPS API endpoint, exe0/exe1 token generation, VM-scoped tokens
+- `shelley-details.md` — Full Shelley capabilities, BYOK, subagents, skills, browser profiling
+- `idea-templates.md` — Template gallery, available templates, custom images
 
 The reference below covers the full platform. If something seems outdated, fetch the upstream docs.
 
@@ -64,14 +73,15 @@ ssh exe.dev ls --json                        # list VMs (JSON)
 ssh exe.dev rm <vmname>                      # delete VM
 ssh exe.dev restart <vmname>                 # restart VM
 ssh exe.dev rename <old> <new>               # rename VM
-ssh exe.dev cp <source> <dest>               # clone VM with disk
+ssh exe.dev cp <source> <dest>               # clone VM (copy-on-write, near-instant)
+ssh exe.dev tag <vmname> <tag>               # tag a VM
 ```
 
 ### Other Lobby Commands
 
 ```
 ssh exe.dev whoami                           # show account info
-ssh exe.dev ssh-key                          # manage SSH keys
+ssh exe.dev ssh-key                          # manage SSH keys (add/list)
 ssh exe.dev shelley install <vmname>         # upgrade Shelley agent
 ssh exe.dev browser <vmname>                 # open VM in browser
 ssh exe.dev help                             # show help
@@ -129,6 +139,7 @@ ssh exe.dev share add <vmname> <email>       # invite by email
 ssh exe.dev share add-link <vmname>          # generate share link
 ssh exe.dev share remove-link <vmname>       # revoke share link
 ssh exe.dev share remove <vmname> <email>    # revoke user access
+ssh exe.dev share show <vmname>              # view current sharing status
 ssh exe.dev share port <vmname> <port>       # change proxy port
 ```
 
@@ -142,7 +153,7 @@ TLS certificates provisioned automatically.
 
 ## LLM Gateway
 
-Built-in proxy to LLM providers at `http://169.254.169.254/gateway/llm/<provider>`. No API keys required. Included token allocation with subscription.
+Built-in proxy to LLM providers at `http://169.254.169.254/gateway/llm/<provider>`. No API keys required. Subscription includes monthly token allocation; additional tokens available as pay-as-you-go credits.
 
 Providers: `anthropic`, `openai`, `fireworks`
 
@@ -177,13 +188,51 @@ All three fields (`to`, `subject`, `body`) are required. `to` must match your re
 
 ## Shelley
 
-Web-based coding agent included on default exeuntu VMs. Accepts natural language tasks — installs software, builds sites, browses the web. Runs on port 9999, accessible at `https://<vmname>.shelley.exe.xyz/`. Uses the LLM Gateway by default (no API key needed), but supports custom credentials.
+Web-based, multi-modal coding agent on all default exeuntu VMs. Open source (github.com/boldsoftware/shelley). Runs on port 9999 at `https://<vmname>.shelley.exe.xyz/`.
 
-Customize behavior with guidance files (checked in priority order):
-- `~/.config/shelley/AGENTS.md` — personal config
-- `AGENTS.md`, `CLAUDE.md`, or `DEAR_LLM.md` — project-level, in git root or working directory
+Key capabilities: natural language task execution, browser tool with profiling, subagents with context continuation, skills system, conversation distillation (LLM-powered context optimization), diff viewer, HTML iframe output (Vega-Lite, etc.), shell commands in chat (`!bash`, `!git show HEAD`), multi-language support, self-upgrade from UI, BYOK (Anthropic, OpenAI, Gemini, z.ai) or LLM Gateway by default.
 
-Upgrade to latest: `ssh exe.dev shelley install <vmname>` (VMs ship the version from creation time).
+Guidance files (priority order): `~/.config/shelley/AGENTS.md` → `AGENTS.md` → `CLAUDE.md` → `DEAR_LLM.md`
+
+Upgrade: `ssh exe.dev shelley install <vmname>` or from Shelley's UI.
+
+See `references/shelley-details.md` for full feature documentation.
+
+## HTTPS API
+
+Programmatic VM management via `POST https://exe.dev/exec` with bearer token auth. The `args` array mirrors the SSH CLI:
+
+```bash
+curl -X POST https://exe.dev/exec \
+  -H "Authorization: Bearer exe0...." \
+  -H "Content-Type: application/json" \
+  -d '{"args": ["ls", "--json"]}'
+```
+
+Tokens (exe0 format) are generated locally by signing permissions JSON with your SSH key — no web UI needed. Supports expiration, command restrictions, and custom context. VM-scoped tokens work with Bearer and Basic auth (git-compatible).
+
+See `references/api-tokens.md` for token generation, permissions, and VM-scoped tokens.
+
+## Idea Templates
+
+Pre-configured VM templates at `exe.dev/idea` (also `exe.new/<template>`). Templates include a container image and a Shelley prompt that auto-configures the app with auth.
+
+Available: Gitea, VS Code, Ghost, Minecraft, Grafana, Outline, OpenClaw, Marimo, and more. Check `exe.dev/idea` for the current list.
+
+See `references/idea-templates.md` for details.
+
+## VSCode Integration
+
+Connect VS Code directly to a VM:
+```
+vscode://vscode-remote/ssh-remote+<vmname>.exe.xyz/home/exedev
+```
+
+Also available from the exe.dev dashboard.
+
+## Tab Completion
+
+VM name tab completion available for zsh, bash, and fish. Check upstream docs for setup instructions.
 
 ## SSH Configuration
 

--- a/plugins/exe-dev/skills/exe-dev-knowledge/references/api-tokens.md
+++ b/plugins/exe-dev/skills/exe-dev-knowledge/references/api-tokens.md
@@ -1,0 +1,100 @@
+# HTTPS API & Tokens
+
+exe.dev exposes a programmatic HTTPS API alongside the SSH CLI. This enables automation, CI/CD, and integrations without SSH.
+
+## Endpoint
+
+```
+POST https://exe.dev/exec
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{"args": ["ls", "--json"]}
+```
+
+The `args` array mirrors the SSH CLI — anything you can run as `ssh exe.dev <command>` works here.
+
+## Token System (exe0)
+
+Tokens are generated locally using SSH key signing — no web UI needed.
+
+### Token Format
+
+```
+exe0.[permissions_base64].[signature_base64]
+```
+
+- `exe0` prefix identifies the token type
+- Permissions are a JSON object, base64-encoded
+- Signature is created with your SSH private key
+
+### Generating a Token
+
+```bash
+# Create permissions JSON
+PERMS='{"exp":"2026-04-01T00:00:00Z"}'
+
+# Sign with SSH key (produces armored signature)
+echo -n "$PERMS" | ssh-keygen -Y sign -f ~/.ssh/id_ed25519 -n exe0@exe.dev
+
+# Assemble: exe0.<base64_perms>.<base64_sig>
+```
+
+The signing namespace is `exe0@exe.dev`.
+
+### Permission Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `exp` | RFC 3339 timestamp | Token expires after this time |
+| `nbf` | RFC 3339 timestamp | Token not valid before this time |
+| `cmds` | string array | Restrict to specific commands (e.g., `["ls", "new"]`) |
+| `ctx` | object | Custom JSON data — passed to VM servers via proxy headers |
+
+### Examples
+
+```json
+// Read-only token (ls only, expires in 1 hour)
+{"exp":"2026-03-13T19:00:00Z","cmds":["ls"]}
+
+// Full access, valid for 30 days
+{"exp":"2026-04-13T00:00:00Z"}
+
+// Create-only with custom context
+{"cmds":["new"],"ctx":{"team":"backend","env":"staging"}}
+```
+
+## VM-Scoped Tokens
+
+For authenticating against a specific VM's HTTP proxy (not the lobby), use namespace `v0@VMNAME.exe.xyz`:
+
+```bash
+echo -n "$PERMS" | ssh-keygen -Y sign -f ~/.ssh/id_ed25519 -n v0@myvm.exe.xyz
+```
+
+VM-scoped tokens work with both Bearer and Basic auth — making them git-compatible:
+
+```bash
+# Bearer auth
+curl -H "Authorization: Bearer exe0...." https://myvm.exe.xyz/api/data
+
+# Basic auth (username ignored, token as password)
+git clone https://x:exe0....@myvm.exe.xyz/repo.git
+```
+
+## Short Tokens (exe1)
+
+Long exe0 tokens can be converted to opaque server-side handles:
+
+```
+exe0-to-exe1 conversion (details TBD — check upstream docs)
+```
+
+The exe1 format is shorter and suitable for embedding in URLs or environment variables.
+
+## Usage Notes
+
+- Tokens are self-contained — the server validates the signature against your registered SSH public keys
+- Revoke by removing the SSH key from your account (`ssh exe.dev ssh-key`)
+- The `ctx` field is forwarded as a proxy header to VMs, enabling custom auth/routing logic
+- For CI/CD: generate a scoped token with minimal `cmds` and a short `exp`

--- a/plugins/exe-dev/skills/exe-dev-knowledge/references/idea-templates.md
+++ b/plugins/exe-dev/skills/exe-dev-knowledge/references/idea-templates.md
@@ -1,0 +1,50 @@
+# Idea Templates
+
+exe.dev provides a gallery of pre-configured VM templates for common use cases.
+
+## Access
+
+- **Gallery**: https://exe.dev/idea
+- **Direct launch**: `exe.new/<template-name>` (e.g., `exe.new/gitea`)
+
+## How Templates Work
+
+Each template includes:
+1. A container image (or the default exeuntu)
+2. A tailored Shelley prompt that sets up the app automatically
+3. Pre-configured auth and networking
+
+When you launch a template, Shelley runs the setup prompt to install and configure the application, including wiring up exe.dev's built-in authentication.
+
+## Available Templates (as of March 2026)
+
+| Template | Description |
+|----------|-------------|
+| Gitea | Self-hosted Git service |
+| VS Code | Code Server (VS Code in browser) |
+| Ghost | Publishing platform |
+| Minecraft | Minecraft server |
+| Grafana | Monitoring dashboards |
+| Outline | Team wiki/knowledge base |
+| OpenClaw | AI agent framework |
+| Marimo | Python notebook (`--image=ghcr.io/marimo-team/marimo:latest-sql`) |
+
+Template availability changes — check `exe.dev/idea` for the current list.
+
+## Custom Images
+
+Beyond templates, create VMs from any container image:
+
+```bash
+ssh exe.dev new --image=ghcr.io/marimo-team/marimo:latest-sql
+ssh exe.dev new --image=ubuntu:24.04
+```
+
+The image must be publicly accessible or from a registry you've authenticated with.
+
+## Use Cases
+
+- **Quick demos**: Spin up a pre-configured app in seconds for a demo or evaluation
+- **Self-hosted tools**: Run Gitea, Outline, or Ghost as your own instance with built-in auth
+- **Game servers**: Minecraft and other game servers with instant HTTPS and sharing
+- **Development environments**: VS Code Server for browser-based development from any device

--- a/plugins/exe-dev/skills/exe-dev-knowledge/references/shelley-details.md
+++ b/plugins/exe-dev/skills/exe-dev-knowledge/references/shelley-details.md
@@ -1,0 +1,69 @@
+# Shelley — Detailed Capabilities
+
+Shelley is exe.dev's web-based coding agent, included on all default exeuntu VMs. It runs on port 9999 at `https://<vmname>.shelley.exe.xyz/`. Open source at github.com/boldsoftware/shelley.
+
+## Key Features
+
+### Multi-Model Support (BYOK)
+Uses the LLM Gateway by default (no API key needed). Also supports bring-your-own-key for:
+- Anthropic (Claude)
+- OpenAI
+- Google Gemini
+- z.ai
+
+### Conversation Distillation
+LLM-powered context window optimization for long sessions. Automatically compresses conversation history to stay within context limits while preserving critical information.
+
+### Browser Tool with Profiling
+Built-in browser for web development workflows. Includes performance profiling for identifying bottlenecks in web apps.
+
+### Subagents
+Launch sub-tasks with context continuation. Subagents inherit the conversation context and can work on isolated subtasks.
+
+### Skills System
+Reusable task patterns that Shelley can invoke. Similar to Claude Code skills but within the Shelley environment.
+
+### Diff Viewer
+Integration with diffs.com for reviewing code changes inline.
+
+### HTML iframe Output
+Render rich visualizations directly in chat — Vega-Lite charts, HTML previews, interactive content.
+
+### Shell Commands in Chat
+Execute commands inline with `!` prefix:
+```
+!bash         # run bash commands
+!git show HEAD  # show latest commit
+```
+
+### Multi-Language Support
+Works across programming languages and frameworks.
+
+### Self-Upgrade
+Update Shelley from within its own UI, in addition to `ssh exe.dev shelley install <vmname>`.
+
+### Notifications
+Command palette integration for task completion alerts.
+
+### Markdown Rendering
+Chat output renders markdown by default for readable formatting.
+
+## Guidance Files
+
+Shelley reads guidance files in priority order:
+1. `~/.config/shelley/AGENTS.md` — personal/global config
+2. `AGENTS.md` — project-level (in git root or working directory)
+3. `CLAUDE.md` — project-level (in git root or working directory)
+4. `DEAR_LLM.md` — project-level (in git root or working directory)
+
+## Upgrading
+
+```bash
+# From lobby
+ssh exe.dev shelley install <vmname>
+
+# Or from Shelley's own UI
+# Use the self-upgrade option in the command palette
+```
+
+VMs ship with the Shelley version available at creation time. Upgrade to get new features.


### PR DESCRIPTION
## Summary

- Add HTTPS API with SSH key-signed tokens (exe0/exe1) for programmatic VM management
- Add Idea Templates gallery (exe.dev/idea, exe.new/<template>)
- Update Shelley section: open-sourced, subagents, skills, conversation distillation, browser profiling, BYOK
- Add VSCode integration, tab completion, VM tag command, share show command
- Create reference files for detailed docs (api-tokens, shelley-details, idea-templates)
- Fix: replace `2>/dev/null` with `|| true` in label creation commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)